### PR TITLE
upgrade rust template and client

### DIFF
--- a/rust/template/Cargo.toml
+++ b/rust/template/Cargo.toml
@@ -2,7 +2,7 @@
 name = "__ALGO__"
 version = "0.1.0"
 
-# Do NOT change the [[bin]] and [lib] sections
+# Changing [[bin]] and [lib] sections may have unintended consequences
 [[bin]]
 name = "pipe"
 path = "bin/pipe.rs"
@@ -10,5 +10,8 @@ path = "bin/pipe.rs"
 name = "algorithm"
 
 [dependencies]
-rustc-serialize = "0.3.19"
-algorithmia = "1.3.0"
+algorithmia = "2.0.0"
+base64 = "0.3.0"
+serde = "0.9.0"
+serde_derive = "0.9.0"
+serde_json = "0.9.0"

--- a/rust/template/bin/pipe.rs
+++ b/rust/template/bin/pipe.rs
@@ -1,65 +1,52 @@
-/*
-* This file provides interop with the langserver
-*/
-extern crate algorithm;  // src/lib.rs builds into the 'algorithm' crate
+// This file provides interop with the langserver
+//
+extern crate algorithm;
 extern crate algorithmia;
-extern crate rustc_serialize;
+extern crate base64;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
 
-use algorithmia::algo::*;
-use algorithmia::error::ApiError;
-use rustc_serialize::json::{self, Json};
-use rustc_serialize::base64::{self, FromBase64, ToBase64};
+use algorithmia::algo::{AlgoInput, AlgoOutput, EntryPoint};
+use algorithmia::error::{Error, ApiError, ErrorKind, ResultExt};
+use serde_json::Value;
 use std::borrow::Cow;
 use std::io::{self, BufRead, Write};
-use std::error::Error as StdError;
 use std::fs::OpenOptions;
 use std::process;
 
 const ALGOOUT: &'static str = "/tmp/algoout";
 
-struct Request<'a> {
-    data: &'a Json,
-    content_type: &'a str,
+#[derive(Deserialize)]
+struct Request {
+    data: Value,
+    content_type: String,
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct AlgoSuccess {
-    result: Json,
+    result: Value,
     metadata: RunnerMetadata,
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct AlgoFailure {
     error: RunnerError,
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct RunnerMetadata {
     content_type: String,
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct RunnerError {
     message: String,
     error_type: &'static str,
 }
 
-impl<'a> Request<'a> {
-    fn from_json(json: &'a Json) -> Result<Request<'a>, String> {
-        let data = json.find("data").expect("Request did not specify data field");
-        let content_type = json.find("content_type")
-                               .expect("Request did not specify content_type")
-                               .as_string()
-                               .expect("Request content_type is not a string");
-        Ok(Request {
-            data: data,
-            content_type: content_type,
-        })
-    }
-}
-
 impl AlgoSuccess {
-    fn new<S: Into<String>>(result: Json, content_type: S) -> AlgoSuccess {
+    fn new<S: Into<String>>(result: Value, content_type: S) -> AlgoSuccess {
         AlgoSuccess {
             result: result,
             metadata: RunnerMetadata { content_type: content_type.into() },
@@ -68,11 +55,22 @@ impl AlgoSuccess {
 }
 
 impl AlgoFailure {
-    fn new<S: Into<String>>(message: S, error_type: &'static str) -> AlgoFailure {
+    fn new(err: &Error) -> AlgoFailure {
+        let message = err.iter().map(|e| e.description()).collect::<Vec<_>>().join("\ncaused by ");
+        AlgoFailure {
+            error: RunnerError {
+                message: message,
+                error_type: "AlgorithmError",
+            },
+        }
+    }
+
+    fn system(err: &Error) -> AlgoFailure {
+        let message = err.iter().map(|e| e.description()).collect::<Vec<_>>().join("\ncaused by ");
         AlgoFailure {
             error: RunnerError {
                 message: message.into(),
-                error_type: error_type,
+                error_type: "SystemError",
             },
         }
     }
@@ -91,38 +89,34 @@ fn main() {
                 flush_std_pipes();
                 serialize_output(output)
             }
-            Err(err) => {
-                json::encode(&AlgoFailure::new(format!("STDIN error: {}", err.description()),
-                                               "SystemError"))
-                    .expect("Failed to encode JSON")
+            Err(_) => {
+                let err = line.chain_err(|| "failed to read stdin").unwrap_err();
+                serde_json::to_string(&AlgoFailure::system(&err)).expect("Failed to encode JSON")
             }
         };
         algoout(&output_json);
     }
 }
 
-fn serialize_output(output: Result<AlgoOutput, algorithmia::error::Error>) -> String {
+impl From<AlgoOutput> for AlgoSuccess {
+    fn from(output: AlgoOutput) -> AlgoSuccess {
+        match output {
+            AlgoOutput::Text(text) => AlgoSuccess::new(Value::String(text), "text"),
+            AlgoOutput::Json(json_obj) => AlgoSuccess::new(json_obj, "json"),
+            AlgoOutput::Binary(bytes) => {
+                let result = base64::encode(&bytes);
+                AlgoSuccess::new(Value::String(result), "binary")
+            }
+        }
+    }
+}
+
+fn serialize_output(output: Result<AlgoOutput, Error>) -> String {
     let json_result = match output {
-        Ok(AlgoOutput::Text(text)) => {
-            json::encode(&AlgoSuccess::new(Json::String(text), "text"))
-        }
-        Ok(AlgoOutput::Json(json_obj)) => {
-            json::encode(&AlgoSuccess::new(json_obj, "json"))
-        }
-        Ok(AlgoOutput::Binary(bytes)) => {
-            let config = base64::Config {
-                char_set: base64::CharacterSet::Standard,
-                newline: base64::Newline::LF,
-                pad: true,
-                line_length: None,
-            };
-            let result = bytes.to_base64(config);
-            json::encode(&AlgoSuccess::new(Json::String(result), "binary"))
-        }
-        Err(err) => {
-            json::encode(&AlgoFailure::new(err.description(), "AlgorithmError"))
-        }
+        Ok(output) => serde_json::to_string(&AlgoSuccess::from(output)),
+        Err(err) => serde_json::to_string(&AlgoFailure::new(&err)),
     };
+
     json_result.expect("Failed to encode JSON")
 }
 
@@ -144,21 +138,23 @@ fn algoout(output_json: &str) {
     };
 }
 
-fn call_algorithm<E: EntryPoint>(algo: &E, stdin: String) -> std::result::Result<AlgoOutput, algorithmia::error::Error> {
-    let parsed = Json::from_str(&stdin).expect("Request is not valid JSON");
-    let req = Request::from_json(&parsed).expect("Failed to deserialize JSON request");
+fn call_algorithm<E: EntryPoint>(algo: &E, stdin: String) -> Result<AlgoOutput, Error> {
+    let req = serde_json::from_str(&stdin).chain_err(|| ErrorKind::DecodeJson("request"))?;
     let Request { data, content_type } = req;
-    let input = match (content_type, data) {
-        ("text", &Json::String(ref text)) => AlgoInput::Text(Cow::Borrowed(text)),
-        ("binary", &Json::String(ref encoded)) => AlgoInput::Binary(Cow::Owned(try!(encoded.from_base64()))),
-        ("json", json_obj) => AlgoInput::Json(Cow::Borrowed(json_obj)),
-        (ct, _) => panic!("Unsupported input content_type: {}", ct),
+    let input = match (&*content_type, data) {
+        ("text", Value::String(text)) => AlgoInput::Text(Cow::Owned(text)),
+        ("binary", Value::String(ref encoded)) => {
+            let bytes =
+                base64::decode(encoded).chain_err(|| ErrorKind::DecodeBase64("request input"))?;
+            AlgoInput::Binary(Cow::Owned(bytes))
+        }
+        ("json", json_obj) => AlgoInput::Json(Cow::Owned(json_obj)),
+        (_, _) => return Err(ErrorKind::InvalidContentType(content_type).into()),
     };
     algo.apply(input).map_err(|e| {
-        ApiError {
+        Error::from(ErrorKind::Api(ApiError {
             message: e.description().into(),
             stacktrace: None.into(),
-        }
-        .into()
+        }))
     })
 }

--- a/rust/template/bin/test
+++ b/rust/template/bin/test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+exec cargo test

--- a/rust/template/src/lib.rs
+++ b/rust/template/src/lib.rs
@@ -1,18 +1,20 @@
+#[macro_use]
 extern crate algorithmia;
-extern crate rustc_serialize;
 
-use algorithmia::*;
-use algorithmia::algo::*;
-use algorithmia::data::*;
+use algorithmia::prelude::*;
 
-#[derive(Default)]
-pub struct Algo;
+algo_entrypoint!(&str);
+fn apply(input: &str) -> Result<String, String> {
+    Ok(format!("Hello {}", input))
+}
 
-// Algo should implement EntryPoint or DecodedEntryPoint
-//   and override at least one of the apply method variants
-impl EntryPoint for Algo {
-    fn apply_str(&self, input: &str) -> Result<AlgoOutput, Box<std::error::Error>> {
-        let msg = format!("Hello {}", input);
-        Ok(AlgoOutput::Text(msg))
+
+#[cfg(test)]
+mod test {
+    use super::apply;
+
+    #[test]
+    fn test_apply() {
+        assert_eq!(&apply("Jane").unwrap(), "Hello Jane");
     }
 }


### PR DESCRIPTION
This does require updating the docker image,
  as the changes depend on Rust 1.15 in the builder image.

This has no effect on published algos, but does break
  compilation of existing rust algorithms.
  The impact is quite small (namely myself, @zeryx,
  and a small handful of unpublished, stale test algos)
  The work-around is to just update dependencies
  and switch from rustc-serialize to serde
  which is often just an attribute change except in
  cases of complex custom JSON parsing.

The improvements in this change include:
- Using the new 2.0 client
- Error messages should be more thorough ("caused by" chain)
- Adds algorithm testing (previously held back for ergonomic reasons)
- Switches to serde serialization/deserialization which is faster and significantly more flexible/configurable (and finally works on stable rust - I've been holding back this change for months, waiting on rust 1.15's stabilized support for serde)
- Algorithm boilerplate is simpler (about half as many lines of code, and hides the complex type signatures) thanks to `algo_entrypoint` macro.