### PR TITLE
Remove driver from builder image

### DIFF
--- a/docker/Dockerfile.single-builder
+++ b/docker/Dockerfile.single-builder
@@ -13,18 +13,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --force-
         linux-image-generic
 
 
-RUN curl -LO http://us.download.nvidia.com/XFree86/Linux-x86_64/367.57/NVIDIA-Linux-x86_64-367.57.run && \
-        chmod +x NVIDIA-Linux-x86_64-367.57.run && \
-        sh ./NVIDIA-Linux-x86_64-367.57.run -s --no-kernel-module
-
 RUN curl -LO https://s3.amazonaws.com/algorithmia-docker/docker-deps/cuda_8.0.44_linux.run && \
     chmod +x cuda_8.0.44_linux.run && \
-    sh ./cuda_8.0.44_linux.run --toolkit --silent
+    sh ./cuda_8.0.44_linux.run --toolkit --silent && \
+    rm cuda_8.0.44_linux.run
 
 RUN curl -LO https://s3.amazonaws.com/algorithmia-docker/docker-deps/cudnn-8.0-linux-x64-v5.1.tgz && \
     tar -xf cudnn-8.0-linux-x64-v5.1.tgz && \
     mv cuda/include/* /usr/local/cuda/include && \
-    mv cuda/lib64/* /usr/local/cuda/lib64
+    mv cuda/lib64/* /usr/local/cuda/lib64 && \
+    rm cudnn-8.0-linux-x64-v5.1.tgz
 
 RUN ldconfig /usr/local/cuda/lib64
 ENV PATH=/usr/local/cuda/bin:$PATH \


### PR DESCRIPTION
a version of cuda remains so that packages like pycuda can be installed via pip since they build against the cuda headers