### PR TITLE
replacing relative URL with absolute

### DIFF
--- a/java/pipe/src/main/java/com/algorithmia/JarRunner.java
+++ b/java/pipe/src/main/java/com/algorithmia/JarRunner.java
@@ -200,8 +200,8 @@ public class JarRunner {
     private ClassLoader loadJars(String workingDirectory) {
         // Load JARs
         String[] extensions = {"jar"};
-        File absolutePath = new File((new File(workingDirectory)).getAbsolutePath());
-        Collection<File> jarFiles = FileUtils.listFiles(new File(absolutePath), extensions, true); // Recursively find jars
+        File absolutePath = (new File(workingDirectory)).getAbsoluteFile();
+        Collection<File> jarFiles = FileUtils.listFiles(absolutePath, extensions, true); // Recursively find jars
         List<URL> jarUrls = new ArrayList<URL>(jarFiles.size());
 
 

--- a/java/pipe/src/main/java/com/algorithmia/JarRunner.java
+++ b/java/pipe/src/main/java/com/algorithmia/JarRunner.java
@@ -193,11 +193,15 @@ public class JarRunner {
 
     /**
      * Resolve algorithm with ivy and load JARs into a ClassLoader
+     * Changed by James Sutton on March 19th, 2018
+     * relative path `new File(".")` formatting breaks reflective URI classPath lookup that some algorithms need
+     *  
      */
     private ClassLoader loadJars(String workingDirectory) {
         // Load JARs
         String[] extensions = {"jar"};
-        Collection<File> jarFiles = FileUtils.listFiles(new File(workingDirectory), extensions, true); // Recursively find jars
+        File absolutePath = new File((new File(workingDirectory)).getAbsolutePath());
+        Collection<File> jarFiles = FileUtils.listFiles(new File(absolutePath), extensions, true); // Recursively find jars
         List<URL> jarUrls = new ArrayList<URL>(jarFiles.size());
 
 


### PR DESCRIPTION
Some Algorithms, like https://algorithmia.com/algorithms/weka/WekaClassification use runtime reflection to load bundled jar files when necessary. With adock, this worked fine for our weka algorithms - however with the obsolescence of Adock and it's replacement by langpacks this has introduced a breaking bug to our wekaClassification algorithm and it's derivatives.
[ALGO-351](https://algorithmia.atlassian.net/browse/ALGO-351)
smallest reproduction: [https://algorithmia.com/algorithms/weka/weka_scala_test/edit](https://algorithmia.com/algorithms/weka/weka_scala_test/edit
)
From the weka package, we were able to narrow down the failing code block to this is here:
```
File file = new File(new URI(part));
```
where `part` defines a classPath URI recovered from `getClass()` being called on the packaged class.
When we are using relative class paths like `file:./lib_managed/some/package.jar` the weka code fails with the following message: `java.lang.IllegalArgumentException: URI is not hierarchical`.

We were able to narrow down where the classPaths are constructed for an algorithm to here, and we discovered that when a relative path (aka `new File(".")`) was passed into the JarRunner, this would replicate the bug we're experiencing.

Bear in mind that no experimental testing has been performed, besides basic "does this break any other part of the JarRunner code?" sanity checks. As I don't have exposure to our CI tools I will defer this to someone more experienced.