### PR TITLE
Updating the scala langpack to use 2.11.11 from 2.11.7

### DIFF
--- a/scala/template/build.sbt
+++ b/scala/template/build.sbt
@@ -9,7 +9,7 @@ organization := "algorithmia"
 // Allow version to be overwritten with "-DalgoVersion=XXX"
 version := System.getProperty("algo.version", "1.0-SNAPSHOT")
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 mainClass in Compile := Some("algorithmia.Main")
 


### PR DESCRIPTION
This _should be_ backwards compatible across the board, scala supports binary bwc for all revision version changes.

Question is, is this the only place where we need to change the scalaVersion, or is there another location in another repo?