### PR TITLE
Attempt to load the library after installing it so that an error will be thrown in the event of a 'warning' that the package couldn't be installed

### DIFF
--- a/r/template/bin/rip.py
+++ b/r/template/bin/rip.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 def installLatestCranIfNecessary(package):
-    return 'if (!(("{package}"  %in% installed.packages()[, c("Package")]) && (available.packages()["{package}",2] == packageVersion("{package}")))) {{ install.packages("{package}") }}; library("{package}")'.format(package=package)
+    return 'if (!(("{package}"  %in% installed.packages()[, c("Package")]) && (available.packages()["{package}",2] == packageVersion("{package}")))) {{ install.packages("{package}") }}; utils::packageVersion("{package}")'.format(package=package)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -40,10 +40,10 @@ def main():
                     normalPackages.append(line)
             elif tokens[0] == '-t' and len(tokens) == 2: # installs a specific archive from CRAN (most likely)
                 if not args.cran_latest:
-                    rscript.append('install.packages("{package}", repos=NULL, type="source"); library("{package}")'.format(package=tokens[1]))
+                    rscript.append('install.packages("{package}", repos=NULL, type="source"); utils::packageVersion("{package}")'.format(package=tokens[1]))
             elif tokens[0] == '-g' and len(tokens) == 2: # installs from github of the form: username/repo[/subdir][@ref|#pull]
                 if not args.cran_latest:
-                    rscript.append('p_install_gh(c("{package}")); library("{package}")'.format(package=tokens[1]))
+                    rscript.append('p_install_gh(c("{package}")); utils::packageVersion("{package}")'.format(package=tokens[1]))
             elif tokens[0] == '-e' and len(line) > 3:
                 if not args.cran_latest:
                     rscript.append(line[3:])

--- a/r/template/bin/rip.py
+++ b/r/template/bin/rip.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 def installLatestCranIfNecessary(package):
-    return 'if (!(("{}"  %in% installed.packages()[, c("Package")]) && (available.packages()["{}",2] == packageVersion("{}")))) {{ install.packages("{}") }}'.format(package, package, package, package)
+    return 'if (!(("{package}"  %in% installed.packages()[, c("Package")]) && (available.packages()["{package}",2] == packageVersion("{package}")))) {{ install.packages("{package}") }}; library("{package}")'.format(package=package)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -40,10 +40,10 @@ def main():
                     normalPackages.append(line)
             elif tokens[0] == '-t' and len(tokens) == 2: # installs a specific archive from CRAN (most likely)
                 if not args.cran_latest:
-                    rscript.append('install.packages("{}", repos=NULL, type="source")'.format(tokens[1]))
+                    rscript.append('install.packages("{package}", repos=NULL, type="source"); library("{package}")'.format(package=tokens[1]))
             elif tokens[0] == '-g' and len(tokens) == 2: # installs from github of the form: username/repo[/subdir][@ref|#pull]
                 if not args.cran_latest:
-                    rscript.append('p_install_gh(c("{}"))'.format(tokens[1]))
+                    rscript.append('p_install_gh(c("{package}")); library("{package}")'.format(package=tokens[1]))
             elif tokens[0] == '-e' and len(line) > 3:
                 if not args.cran_latest:
                     rscript.append(line[3:])


### PR DESCRIPTION
I'm not sure if this will result in errors compiliing some R algorithms that did in fact get packages installed correctly, however this will definitively prevent erroneous "build successful" for R algorithms when in fact a package was never installed.  R will emit warning messages like:

```
ERROR: dependency ‘dplyr’ is not available for package ‘dbplyr’
* removing ‘/usr/local/lib/R/site-library/dbplyr’
```

or 
```
Warning message:                                                            
package ‘nlme’ is not available (for R version 3.3.3)
```
on package installation, which are clearly more than warnings