### PR TITLE
Tokens for installing from http/github don't match package name

### DIFF
--- a/r/template/bin/rip.py
+++ b/r/template/bin/rip.py
@@ -40,10 +40,17 @@ def main():
                     normalPackages.append(line)
             elif tokens[0] == '-t' and len(tokens) == 2: # installs a specific archive from CRAN (most likely)
                 if not args.cran_latest:
-                    rscript.append('install.packages("{package}", repos=NULL, type="source"); utils::packageVersion("{package}")'.format(package=tokens[1]))
+                    http_url = tokens[1]  # Something like https://cran.r-project.org/src/contrib/R6_2.2.2.tar.gz
+                    gzip_package_name = http_url.split('/')[-1] # R6_2.2.2.tar.gz
+                    if '_' in gzip_package_name: # Scanning CRAN, R packages don't _ in the name, but version needs to be stripped
+                        package_name = '_'.join(gzip_package_name.split('_')[:-1])  # Just in case some package _does_ have an _
+                    else:
+                        package_name = gzip_package_name
+                    package_name = package_name.rstrip('.tar.gz') # remove the .tar.gz if it exist
+                    rscript.append('install.packages("{package}", repos=NULL, type="source"); utils::packageVersion("{package_name}")'.format(package=tokens[1], package_name=package_name))
             elif tokens[0] == '-g' and len(tokens) == 2: # installs from github of the form: username/repo[/subdir][@ref|#pull]
                 if not args.cran_latest:
-                    rscript.append('p_install_gh(c("{package}")); utils::packageVersion("{package}")'.format(package=tokens[1]))
+                    rscript.append('p_install_gh(c("{package}"));'.format(package=tokens[1]))
             elif tokens[0] == '-e' and len(line) > 3:
                 if not args.cran_latest:
                     rscript.append(line[3:])


### PR DESCRIPTION
do some string parsing for http installs and skip validation for github installs since parsing that would be tough.
idk, it's kind of janky but I've been able to install packages via HTTP locally again and would like to get this out into test to validate a few more examples (copied script over to a build machine in test already but would like to validate it "for real").   I figured this sort of weird parsing was probably the best option to still have some guarantee that package install was successful