### PR TITLE
Use a different keyserver to hopefully prevent sporadic errors seen in our build environment

### DIFF
--- a/libraries/python37/Dockerfile
+++ b/libraries/python37/Dockerfile
@@ -34,7 +34,7 @@ RUN set -ex \
     && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
     && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$GPG_KEY" \
+    && gpg --batch --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
     && gpg --batch --verify python.tar.xz.asc python.tar.xz \
     && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
     && rm -rf "$GNUPGHOME" python.tar.xz.asc \

--- a/libraries/python37/Dockerfile
+++ b/libraries/python37/Dockerfile
@@ -28,12 +28,13 @@ ENV PATH /usr/local/bin:$PATH
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
 ENV PYTHON_VERSION 3.7.1
 
+# Setting keyserver per https://github.com/tianon/gosu/issues/17#issuecomment-203074866
 RUN set -ex \
     \
     && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
     && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
+    && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$GPG_KEY" \
     && gpg --batch --verify python.tar.xz.asc python.tar.xz \
     && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
     && rm -rf "$GNUPGHOME" python.tar.xz.asc \


### PR DESCRIPTION
In testing there seems to be some sporadic errors when trying to get the GPG key when installing python, trying to use a different keyserver address here based on some google-fu