### PR TITLE
Use numeric uids/gids instead of named user so that user id lookups aren't required and therefore can use the kaniko cache effectively

### DIFF
--- a/languages/Dockerfile.builder.j2
+++ b/languages/Dockerfile.builder.j2
@@ -7,7 +7,8 @@ LABEL langpacks_version={{langpacks_version}}
 
 # Algo uid is set so that it is known for build caches, but the user id
 # would presumably not be used already on our host (which seems better for security)
-RUN adduser --disabled-password --gecos "" --uid 2222 algo
+ENV ALGO_UID=2222
+RUN adduser --disabled-password --gecos "" --uid $ALGO_UID algo
 
 {% for package in packages %}
 {% if package.script is not none %}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -1,6 +1,7 @@
 FROM {{builder_image}} as builder
 USER 2222
 COPY --chown=2222 algosource /opt/algorithm/
+ENV HOME=/home/algo
 RUN /opt/algorithm/bin/build
 
 FROM {{runner_image}}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -1,13 +1,13 @@
 FROM {{builder_image}} as builder
-USER 2222
-COPY --chown=2222 algosource /opt/algorithm/
+USER $ALGO_UID
+COPY --chown=$ALGO_UID:$ALGO_UID algosource /opt/algorithm/
 ENV HOME=/home/algo
 RUN /opt/algorithm/bin/build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}
-COPY --from=builder --chown=2222 {{artifact.source}} {{artifact.destination}}
+COPY --from=builder --chown=$ALGO_UID:$ALGO_UID {{artifact.source}} {{artifact.destination}}
 {% endfor %}
-USER 2222
+USER $ALGO_UID
 WORKDIR /opt/algorithm
 ENTRYPOINT /bin/init-langserver

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -1,12 +1,12 @@
 FROM {{builder_image}} as builder
-USER algo
-COPY --chown=algo algosource /opt/algorithm/
+USER 2222
+COPY --chown=2222 algosource /opt/algorithm/
 RUN /opt/algorithm/bin/build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}
-COPY --from=builder --chown=algo {{artifact.source}} {{artifact.destination}}
+COPY --from=builder --chown=2222 {{artifact.source}} {{artifact.destination}}
 {% endfor %}
-USER algo
+USER 2222
 WORKDIR /opt/algorithm
 ENTRYPOINT /bin/init-langserver

--- a/languages/Dockerfile.runner.j2
+++ b/languages/Dockerfile.runner.j2
@@ -9,7 +9,8 @@ LABEL langpacks_version={{langpacks_version}}
 
 # Algo uid is set so that it is known for build caches, but the user id
 # would presumably not be used already on our host (which seems better for security)
-RUN adduser --disabled-password --gecos "" --uid 2222 algo
+ENV ALGO_UID=2222
+RUN adduser --disabled-password --gecos "" --uid $ALGO_UID algo
 COPY --from=langserver /bin/init-langserver /bin/init-langserver
 COPY --from=langserver /langserver/target/release/langserver /bin/langserver
 

--- a/libraries/python3-buildtime/Dockerfile
+++ b/libraries/python3-buildtime/Dockerfile
@@ -1,2 +1,2 @@
-COPY python3-buildtime/context/build /opt/algorithm/bin/build
-COPY python3-buildtime/context/test /opt/algorithm/bin/test
+COPY --chown=0:0 python3-buildtime/context/build /opt/algorithm/bin/build
+COPY --chown=0:0 python3-buildtime/context/test /opt/algorithm/bin/test

--- a/libraries/python3-runtime/Dockerfile
+++ b/libraries/python3-runtime/Dockerfile
@@ -1,1 +1,1 @@
-COPY python3-runtime/context/pipe /opt/algorithm/bin/pipe
+COPY --chown=0:0 python3-runtime/context/pipe /opt/algorithm/bin/pipe


### PR DESCRIPTION
The change requires a bump in the version of kaniko in use (https://github.com/algorithmiaio/kaniko/pull/2) but I also have a couple questions to resolve via committee here:
1. The builder/runner images already end with the `USER algo` lines so having it in the compile dockerfile is a bit unnecessary
2. Choice of 2222 was totally arbitrary but didn't know if others were aware of this - https://github.com/algorithmiaio/langpacks/blob/master/languages/Dockerfile.builder.j2#L10.  I chose it because it seemed like a good idea to not be the same as users that might already exist on our system, and because we've had confusing situations in the past with local development where something works for one person and not another person because the UID would be 1000 or something, but some people's desktop UIDs are 1001 etc.
3. We could also have the algo_uid be a variable that legit adds in to builder/runner/compile images but that felt a bit like overkill.  All that matters is that the ID is the same in the 3 images (which they are fixed here).