### PR TITLE
Copy Python37 install to Python36 directory

### DIFF
--- a/languages/Dockerfile.builder.j2
+++ b/languages/Dockerfile.builder.j2
@@ -20,6 +20,6 @@ RUN /tmp/{{package.script}}
 {% endfor %}
 {% endfor %}
 
-USER algo
+USER $ALGO_UID
 
 WORKDIR /opt/algorithm

--- a/languages/Dockerfile.runner.j2
+++ b/languages/Dockerfile.runner.j2
@@ -25,7 +25,7 @@ RUN /tmp/{{package.script}}
 {% endfor %}
 {% endfor %}
 
-USER algo
+USER $ALGO_UID
 
 WORKDIR /opt/algorithm
 ENTRYPOINT /bin/init-langserver

--- a/libraries/python3-runtime/Dockerfile
+++ b/libraries/python3-runtime/Dockerfile
@@ -1,1 +1,2 @@
 COPY --chown=0:0 python3-runtime/context/pipe /opt/algorithm/bin/pipe
+ENV PATH=$PATH:/home/algo/.local/bin

--- a/libraries/python36/Dockerfile
+++ b/libraries/python36/Dockerfile
@@ -1,0 +1,95 @@
+# Lightly modified from https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile
+
+# MIT license from initial repo
+# Copyright (c) 2014 Docker, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ensure local python is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
+
+ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+ENV PYTHON_VERSION 3.6.8
+
+# Setting keyserver per https://github.com/tianon/gosu/issues/17#issuecomment-203074866
+RUN set -ex \
+    \
+    && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+    && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$GPG_KEY" \
+    && gpg --batch --verify python.tar.xz.asc python.tar.xz \
+    && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+    && rm -rf "$GNUPGHOME" python.tar.xz.asc \
+    && mkdir -p /usr/src/python \
+    && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+    && rm python.tar.xz \
+    \
+    && cd /usr/src/python \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && ./configure \
+        --build="$gnuArch" \
+        --enable-loadable-sqlite-extensions \
+        --enable-shared \
+        --with-system-expat \
+        --with-system-ffi \
+        --without-ensurepip \
+    && make -j "$(nproc)" \
+    && make install \
+    && ldconfig \
+    \
+    && find /usr/local -depth \
+        \( \
+            \( -type d -a \( -name test -o -name tests \) \) \
+            -o \
+            \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+        \) -exec rm -rf '{}' + \
+    && rm -rf /usr/src/python \
+    \
+    && python3 --version
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+    && ln -s idle3 idle \
+    && ln -s pydoc3 pydoc \
+    && ln -s python3 python \
+    && ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 18.1
+
+RUN set -ex; \
+    \
+    wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+    \
+    python get-pip.py \
+        --disable-pip-version-check \
+        --no-cache-dir \
+        "pip==$PYTHON_PIP_VERSION" \
+    ; \
+    pip --version; \
+    \
+    find /usr/local -depth \
+        \( \
+            \( -type d -a \( -name test -o -name tests \) \) \
+            -o \
+            \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+        \) -exec rm -rf '{}' +; \
+    rm -f get-pip.py

--- a/libraries/python36/install.sh
+++ b/libraries/python36/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Install a handful of build dependencies needed for python
+set -e
+
+apt-get -y update
+
+apt-get install --no-install-recommends -y \
+    build-essential \
+    ca-certificates \
+    checkinstall \
+    libbz2-dev \
+    libc6-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libncursesw5-dev \
+    libreadline-gplv2-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    tk-dev \
+    uuid-dev \
+    wget
+
+rm -rf /var/lib/apt/lists/*

--- a/libraries/pytorch-1.0.0/Dockerfile
+++ b/libraries/pytorch-1.0.0/Dockerfile
@@ -1,1 +1,1 @@
-RUN pip install -r pytorch-1.0.0/context/requirements.txt
+RUN pip install https://download.pytorch.org/whl/cu90/torch-1.0.0-cp37-cp37m-linux_x86_64.whl

--- a/libraries/pytorch-1.0.0/Dockerfile
+++ b/libraries/pytorch-1.0.0/Dockerfile
@@ -1,0 +1,1 @@
+RUN pip install -r pytorch-1.0.0/context/requirements.txt

--- a/libraries/pytorch-1.0.0/context/requirements.txt
+++ b/libraries/pytorch-1.0.0/context/requirements.txt
@@ -1,1 +1,0 @@
-https://download.pytorch.org/whl/cu90/torch-1.0.0-cp37-cp37m-linux_x86_64.whl

--- a/libraries/pytorch-1.0.0/install.sh
+++ b/libraries/pytorch-1.0.0/install.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Install the requirements defined in the requirements.txt file in the template
-pip install -r context/requirements.txt

--- a/libraries/tensorflow-gpu-1.12/Dockerfile
+++ b/libraries/tensorflow-gpu-1.12/Dockerfile
@@ -1,6 +1,2 @@
-#!/bin/bash
-
-set -e
-
 # Install the requirements defined in the requirements.txt file in the template
-pip install -r context/requirements.txt
+RUN pip install -r tensorflow-gpu-1.12/context/requirements.txt

--- a/libraries/tensorflow-gpu-1.12/Dockerfile
+++ b/libraries/tensorflow-gpu-1.12/Dockerfile
@@ -1,2 +1,3 @@
-# Install the requirements defined in the requirements.txt file in the template
-RUN pip install -r tensorflow-gpu-1.12/context/requirements.txt
+RUN pip install \
+ keras==2.1.4 \
+ tensorflow-gpu==1.12.0

--- a/libraries/tensorflow-gpu-1.12/context/requirements.txt
+++ b/libraries/tensorflow-gpu-1.12/context/requirements.txt
@@ -1,2 +1,0 @@
-keras==2.1.4
-tensorflow-gpu==1.12.0


### PR DESCRIPTION
Also adding a small tweak to the python runtime so pip-installed binaries are available on PATH.  I will be testing this in test and might have to submit tweaks but it's a little easier to test this using test infra if I merge first