### PR TITLE
Some builder backends don't resolve environment variables in chown commands, so we have to use the numeric id

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -1,13 +1,13 @@
 FROM {{builder_image}} as builder
-USER $ALGO_UID
-COPY --chown=$ALGO_UID:$ALGO_UID algosource /opt/algorithm/
+USER 2222
+COPY --chown=2222:2222 algosource /opt/algorithm/
 ENV HOME=/home/algo
 RUN /opt/algorithm/bin/build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}
-COPY --from=builder --chown=$ALGO_UID:$ALGO_UID {{artifact.source}} {{artifact.destination}}
+COPY --from=builder --chown=2222:2222 {{artifact.source}} {{artifact.destination}}
 {% endfor %}
-USER $ALGO_UID
+USER 2222
 WORKDIR /opt/algorithm
 ENTRYPOINT /bin/init-langserver


### PR DESCRIPTION
I feel like this is a little unfortunate (and could still use $ALGO_UID in the USER statement but felt like may as well be consistent here)