### PR TITLE
Platform 2297 ipa bin build security

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -3,7 +3,7 @@ USER 2222
 # Docker build commands don't resolve environment variables so need this to either be numeric or a build argument
 COPY --chown=2222:2222 algosource /opt/algorithm/
 ENV HOME=/home/algo
-RUN /usr/local/bin/mia-build
+RUN /usr/local/bin/algorithmia-build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -3,7 +3,7 @@ USER 2222
 # Docker build commands don't resolve environment variables so need this to either be numeric or a build argument
 COPY --chown=2222:2222 algosource /opt/algorithm/
 ENV HOME=/home/algo
-RUN /usr/local/bin/mia_build
+RUN /usr/local/bin/mia-build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -3,7 +3,7 @@ USER 2222
 # Docker build commands don't resolve environment variables so need this to either be numeric or a build argument
 COPY --chown=2222:2222 algosource /opt/algorithm/
 ENV HOME=/home/algo
-RUN /opt/algorithm/bin/build
+RUN /usr/local/bin/build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -3,7 +3,7 @@ USER 2222
 # Docker build commands don't resolve environment variables so need this to either be numeric or a build argument
 COPY --chown=2222:2222 algosource /opt/algorithm/
 ENV HOME=/home/algo
-RUN /usr/local/bin/build
+RUN /usr/local/bin/mia_build
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}

--- a/languages/python2/config.json
+++ b/languages/python2/config.json
@@ -1,8 +1,6 @@
 {
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
-        {"source":"/opt/algorithm/src", "destination":"/opt/algorithm/src/"},
-        {"source":"/opt/algorithm/algorithmia.conf", "destination":"/opt/algorithm/algorithmia.conf"},
-        {"source":"/opt/algorithm/requirements.txt", "destination":"/opt/algorithm/requirements.txt"}
+        {"source":"/opt/algorithm", "destination":"/opt/algorithm"}
     ]
 }

--- a/languages/python2/config.json
+++ b/languages/python2/config.json
@@ -1,6 +1,6 @@
 {
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
-        {"source":"/opt/algorithm", "destination":"/opt/algorithm"}
+        {"source":"/opt/algorithm", "destination":"/opt/algorithm/"}
     ]
 }

--- a/languages/python3/config.json
+++ b/languages/python3/config.json
@@ -1,8 +1,6 @@
 {
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
-        {"source":"/opt/algorithm/src", "destination":"/opt/algorithm/src/"},
-        {"source":"/opt/algorithm/algorithmia.conf", "destination":"/opt/algorithm/algorithmia.conf"},
-        {"source":"/opt/algorithm/requirements.txt", "destination":"/opt/algorithm/requirements.txt"}
+        {"source":"/opt/algorithm", "destination":"/opt/algorithm"}
     ]
 }

--- a/languages/python3/config.json
+++ b/languages/python3/config.json
@@ -1,6 +1,6 @@
 {
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
-        {"source":"/opt/algorithm", "destination":"/opt/algorithm"}
+        {"source":"/opt/algorithm", "destination":"/opt/algorithm/"}
     ]
 }

--- a/libraries/python2-buildtime/Dockerfile
+++ b/libraries/python2-buildtime/Dockerfile
@@ -1,3 +1,3 @@
-COPY --chown=0:0 python2-buildtime/context/build /usr/local/bin/mia_build
-COPY --chown=0:0 python2-buildtime/context/test /usr/local/bin/mia_test
+COPY --chown=0:0 python2-buildtime/context/build /usr/local/bin/mia-build
+COPY --chown=0:0 python2-buildtime/context/test /usr/local/bin/mia-test
 ENV PATH=$PATH:/home/algo/.local/bin

--- a/libraries/python2-buildtime/Dockerfile
+++ b/libraries/python2-buildtime/Dockerfile
@@ -1,3 +1,3 @@
-COPY --chown=0:0 python2-buildtime/context/build /opt/algorithm/bin/build
-COPY --chown=0:0 python2-buildtime/context/test /opt/algorithm/bin/test
+COPY --chown=0:0 python2-buildtime/context/build /usr/local/bin/mia_build
+COPY --chown=0:0 python2-buildtime/context/test /usr/local/bin/mia_test
 ENV PATH=$PATH:/home/algo/.local/bin

--- a/libraries/python2-buildtime/Dockerfile
+++ b/libraries/python2-buildtime/Dockerfile
@@ -1,3 +1,3 @@
-COPY --chown=0:0 python2-buildtime/context/build /usr/local/bin/mia-build
-COPY --chown=0:0 python2-buildtime/context/test /usr/local/bin/mia-test
+COPY --chown=0:0 python2-buildtime/context/build /usr/local/bin/algorithmia-build
+COPY --chown=0:0 python2-buildtime/context/test /usr/local/bin/algorithmia-test
 ENV PATH=$PATH:/home/algo/.local/bin

--- a/libraries/python3-buildtime/Dockerfile
+++ b/libraries/python3-buildtime/Dockerfile
@@ -1,3 +1,3 @@
-COPY --chown=0:0 python3-buildtime/context/build /usr/local/bin/mia-build
-COPY --chown=0:0 python3-buildtime/context/test /usr/local/bin/mia-test
+COPY --chown=0:0 python3-buildtime/context/build /usr/local/bin/algorithmia-build
+COPY --chown=0:0 python3-buildtime/context/test /usr/local/bin/algorithmia-test
 ENV PATH=$PATH:/home/algo/.local/bin

--- a/libraries/python3-buildtime/Dockerfile
+++ b/libraries/python3-buildtime/Dockerfile
@@ -1,3 +1,3 @@
-COPY --chown=0:0 python3-buildtime/context/build /opt/algorithm/bin/build
-COPY --chown=0:0 python3-buildtime/context/test /opt/algorithm/bin/test
+COPY --chown=0:0 python3-buildtime/context/build /usr/local/bin/mia_build
+COPY --chown=0:0 python3-buildtime/context/test /usr/local/bin/mia_test
 ENV PATH=$PATH:/home/algo/.local/bin

--- a/libraries/python3-buildtime/Dockerfile
+++ b/libraries/python3-buildtime/Dockerfile
@@ -1,3 +1,3 @@
-COPY --chown=0:0 python3-buildtime/context/build /usr/local/bin/mia_build
-COPY --chown=0:0 python3-buildtime/context/test /usr/local/bin/mia_test
+COPY --chown=0:0 python3-buildtime/context/build /usr/local/bin/mia-build
+COPY --chown=0:0 python3-buildtime/context/test /usr/local/bin/mia-test
 ENV PATH=$PATH:/home/algo/.local/bin


### PR DESCRIPTION
Bin/build security fix for IPA algos; build script is now placed in and used from `/usr/local/bin` rather than the working directory

Work to be done
- Legit filter function