### PR TITLE
enabling pytorch full functionality w/o reqs.txt

### DIFF
--- a/libraries/pytorch-1.0.0/Dockerfile
+++ b/libraries/pytorch-1.0.0/Dockerfile
@@ -1,1 +1,2 @@
+RUN pip install numpy==1.16.0
 RUN pip install torch==1.0.0


### PR DESCRIPTION
As @dinoboy197 noticed, the pytorch image isn't feature complete, as it needs numpy to work properly - pytorch uses numpy but doesn't install it automatically for some reason.

This isn't an issue from a users perspective, but it is a problem from a testing perspective, and it makes my "how to make & test an IPA package" tutorial a bit flimsy.

By adding numpy here, it will mean that an IPA dev will be able to fully test a pytorch project inside of a docker environment without needing to `pip install -r requirements.txt` like our platform does presently.

Alternatively, we could make a `docker run` script that automatically executes `pip install -r requirements.txt` and runs the `__ALGO___test.py` script automatically. That could be a nice improvement but it would require some development time.