### PR TITLE
ALGO-579 simplified imports for dotnet sdk installation

### DIFF
--- a/languages/Dockerfile.builder.j2
+++ b/languages/Dockerfile.builder.j2
@@ -26,6 +26,9 @@ RUN /tmp/{{package.script}}
 RUN mkdir /opt/algorithm
 RUN chown $ALGO_UID:$ALGO_UID /opt/algorithm
 
+
+# WORKDIR does not respect the USER operation, which means that /opt/algorithm is owned by root unless previously created
+# https://github.com/moby/moby/issues/20295
 USER $ALGO_UID
 
 WORKDIR /opt/algorithm

--- a/languages/Dockerfile.runner.j2
+++ b/languages/Dockerfile.runner.j2
@@ -25,10 +25,6 @@ RUN /tmp/{{package.script}}
 {% endfor %}
 {% endfor %}
 
-# Create the /opt/algorithm directory writeable by algo user so that build/run scripts can create directories. 
-# For example a compiled language like C# creates a bin directory for the compiled binary.
-RUN mkdir /opt/algorithm
-RUN chown $ALGO_UID:$ALGO_UID /opt/algorithm
 USER $ALGO_UID
 
 WORKDIR /opt/algorithm

--- a/libraries/csharp-dotnet-core2/Dockerfile
+++ b/libraries/csharp-dotnet-core2/Dockerfile
@@ -1,4 +1,4 @@
-# Sourced in part from https://github.com/algorithmiaio/langpacks/blob/master/libraries/python36/Dockerfile
+# Sourced in part from https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current
 
 RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
@@ -38,6 +38,7 @@ ENV UBUNTU_VERSION 16.04
 RUN wget -q https://packages.microsoft.com/config/ubuntu/$UBUNTU_VERSION/packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 
+# Installs necessary apt-transport-https package, defined in packages-microsoft-prod.deb
 RUN apt-get install -y apt-transport-https && \
     apt-get update && \
     apt-get install -y dotnet-sdk-$DOTNET_SDK_VERSION

--- a/libraries/csharp-dotnet-core2/Dockerfile
+++ b/libraries/csharp-dotnet-core2/Dockerfile
@@ -41,6 +41,7 @@ RUN dpkg -i packages-microsoft-prod.deb
 # Installs necessary apt-transport-https package, defined in packages-microsoft-prod.deb
 RUN apt-get install -y apt-transport-https && \
     apt-get update && \
-    apt-get install -y dotnet-sdk-$DOTNET_SDK_VERSION
+    apt-get install -y dotnet-sdk-$DOTNET_SDK_VERSION && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN dotnet help

--- a/libraries/csharp-dotnet-core2/Dockerfile
+++ b/libraries/csharp-dotnet-core2/Dockerfile
@@ -1,5 +1,5 @@
 # Sourced in part from https://dotnet.microsoft.com/download/linux-package-manager/ubuntu16-04/sdk-current
-
+# We also used some parts of https://github.com/dotnet/dotnet-docker/blob/master/2.2/sdk/stretch/amd64/Dockerfile
 RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
         build-essential \

--- a/libraries/csharp-dotnet-core2/Dockerfile
+++ b/libraries/csharp-dotnet-core2/Dockerfile
@@ -2,22 +2,18 @@ RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
         build-essential \
         ca-certificates \
-        checkinstall \
-        libbz2-dev \
-        libc6-dev \
-        libffi-dev \
-        libgdbm-dev \
-        libncursesw5-dev \
-        libreadline-gplv2-dev \
-        libsqlite3-dev \
         libssl-dev \
-        tk-dev \
-        uuid-dev \
         wget
 
-RUN wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
+# Install .NET Core SDK
+ENV DOTNET_SDK_VERSION 2.2
+ENV UBUNTU_VERSION 16.04
+
+RUN wget -q https://packages.microsoft.com/config/ubuntu/$UBUNTU_VERSION/packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 
 RUN apt-get install -y apt-transport-https
 RUN apt-get update
-RUN apt-get install -y dotnet-sdk-2.2 
+RUN apt-get install -y dotnet-sdk-$DOTNET_SDK_VERSION
+
+RUN dotnet help

--- a/libraries/csharp-dotnet-core2/Dockerfile
+++ b/libraries/csharp-dotnet-core2/Dockerfile
@@ -1,14 +1,40 @@
+# Sourced in part from https://github.com/algorithmiaio/langpacks/blob/master/libraries/python36/Dockerfile
+
 RUN apt-get -y update && \
     apt-get install --no-install-recommends -y \
         build-essential \
         ca-certificates \
         libssl-dev \
-        wget
+        wget && \
+        rm -rf /var/lib/apt/lists/*
+
+# MIT license from initial repo
+# Copyright (c) 2014 Docker, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 # Install .NET Core SDK
 ENV DOTNET_SDK_VERSION 2.2
 ENV UBUNTU_VERSION 16.04
 
+# Downloads latest dpkg for current ubuntu version
 RUN wget -q https://packages.microsoft.com/config/ubuntu/$UBUNTU_VERSION/packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 

--- a/libraries/csharp-dotnet-core2/Dockerfile
+++ b/libraries/csharp-dotnet-core2/Dockerfile
@@ -12,8 +12,8 @@ ENV UBUNTU_VERSION 16.04
 RUN wget -q https://packages.microsoft.com/config/ubuntu/$UBUNTU_VERSION/packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 
-RUN apt-get install -y apt-transport-https
-RUN apt-get update
-RUN apt-get install -y dotnet-sdk-$DOTNET_SDK_VERSION
+RUN apt-get install -y apt-transport-https && \
+    apt-get update && \
+    apt-get install -y dotnet-sdk-$DOTNET_SDK_VERSION
 
 RUN dotnet help


### PR DESCRIPTION
reduced imports to bare minimum, since we use ubuntu 16.04 as a base image, the microsoft base images are incompatible - however this method works fine as is.