### PR TITLE
Removing the bin directory from java's .gitignore

### DIFF
--- a/java/template/.gitignore
+++ b/java/template/.gitignore
@@ -1,6 +1,5 @@
 # Algorithmia gitignore
 
-bin
 ivy
 dist
 logs


### PR DESCRIPTION
In the past we used the use the working directory for zipping up the source where the build files existed.
Now, when we build, we use the actual commit SHA so the build scripts need to be checked in - this is the
way things exist in all other classic languages.