### PR TITLE
Add git to python Dockerfile installs

### DIFF
--- a/libraries/python36/Dockerfile
+++ b/libraries/python36/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get -y update && \
         libssl-dev \
         tk-dev \
         uuid-dev \
-        wget && \
+        wget \
+        git && \
     rm -rf /var/lib/apt/lists/*
 
 # MIT license from initial repo

--- a/libraries/python37/Dockerfile
+++ b/libraries/python37/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get -y update && \
         libssl-dev \
         tk-dev \
         uuid-dev \
-        wget && \
+        wget \
+        git && \
     rm -rf /var/lib/apt/lists/*
 
 # MIT license from initial repo


### PR DESCRIPTION
@pmcq this should solve the issue of not being able to use pip install to install from github because `git` isn't installed. Added JPeck for visibility