### PR TITLE
fix shell scripts that fail with `set -eu` command

### DIFF
--- a/libraries/anaconda3-buildtime/context/build
+++ b/libraries/anaconda3-buildtime/context/build
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -e
+
+FILE="$1"
+
+set -eu
 
 ROOTDIR=/opt/algorithm
 # The argument provided to this script ($1) denotes the path to the yaml file which contains all of the necessary features
@@ -10,9 +13,9 @@ ROOTDIR=/opt/algorithm
 # requirement.
 
 . /opt/conda/etc/profile.d/conda.sh
-if [ -z "$1" ]; then
+if [ -z "$FILE" ]; then
     conda env update --prefix $ANACONDA_ENV --file $ROOTDIR/requirements.yml
 else
-    conda env update --prefix $ANACONDA_ENV --file $1
+    conda env update --prefix $ANACONDA_ENV --file $FILE
     chown algo:algo -R $ANACONDA_ENV
 fi

--- a/libraries/anaconda3-buildtime/context/build
+++ b/libraries/anaconda3-buildtime/context/build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -e
 
 ROOTDIR=/opt/algorithm
 # The argument provided to this script ($1) denotes the path to the yaml file which contains all of the necessary features

--- a/libraries/anaconda3-solaris-0.1.2/context/solaris-build
+++ b/libraries/anaconda3-solaris-0.1.2/context/solaris-build
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -e
 
 . /opt/conda/etc/profile.d/conda.sh
 

--- a/libraries/anaconda3-solaris-0.1.2/context/solaris-build
+++ b/libraries/anaconda3-solaris-0.1.2/context/solaris-build
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-set -e
+DIRECTORY="$1"
+
+set -eu
 
 . /opt/conda/etc/profile.d/conda.sh
 
-# $1 is the variable path to the local solaris-git directory on the system
-cd $1
+# The argument provided to this script ($1) denotes the path to locally installed solaris build path, which we use
+# to update the anaconda environment.
+
+cd $DIRECTORY
 conda env update --prefix $ANACONDA_ENV --file=environment.yml
 conda activate $ANACONDA_ENV
 pip install .


### PR DESCRIPTION
the changes requested by jamesA resulted in the following exception which were not returned by the package set construction process:
`/usr/local/bin/algorithmia-build: line 13: $1: unbound variable`
This seems to be due to the introduction of the `u` operator in the `set -eu` requested modification for build & solaris-build.