### PR TITLE
anaconda perf improvements (perf/disk size)

### DIFF
--- a/libraries/anaconda35/Dockerfile
+++ b/libraries/anaconda35/Dockerfile
@@ -1,7 +1,6 @@
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH
 ENV ANACONDA_ENV=/home/algo/anaconda_environment
-ENV PYTHONDONTWRITEBYTECODE=true
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \

--- a/libraries/anaconda35/Dockerfile
+++ b/libraries/anaconda35/Dockerfile
@@ -7,10 +7,6 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     curl grep sed dpkg \
     git  && \
-#    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
-#    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
-#    dpkg -i tini.deb && \
-#    rm tini.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/libraries/anaconda35/Dockerfile
+++ b/libraries/anaconda35/Dockerfile
@@ -1,19 +1,19 @@
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PATH /opt/conda/bin:$PATH
 ENV ANACONDA_ENV=/home/algo/anaconda_environment
+ENV PYTHONDONTWRITEBYTECODE=true
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     curl grep sed dpkg \
     git  && \
-    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
-    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
-    dpkg -i tini.deb && \
-    rm tini.deb && \
-    apt-get clean \
-    ; \
+#    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+#    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+#    dpkg -i tini.deb && \
+#    rm tini.deb && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.sh -O ~/anaconda.sh && \
-    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
-    rm ~/anaconda.sh
+RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh

--- a/templates/solaris-0.1.2/requirements.yml
+++ b/templates/solaris-0.1.2/requirements.yml
@@ -4,30 +4,31 @@ channels:
   - defaults
 dependencies:
 # solaris dependencies - don't change these unless you need to, plus it might break solaris
-  - python=3.6
-  - pip=19.0
-  - shapely=1.6.4
-  - fiona=1.8.6
-  - pandas=0.24.2
-  - geopandas>=0.4.1
-  - opencv=3.4.4
-  - numpy=1.16.3
-  - gdal=2.4.1
-  - tqdm=4.31.1
-  - matplotlib=3.1.0
-  - rtree=0.8.3
-  - urllib3=1.24.3
-  - networkx=2.3
-  - rasterio=1.0.23
-  - scipy=1.2.1
-  - scikit-image=0.15.0
-  - tensorflow=1.13.1
-  - pytorch=1.1.0
-  - torchvision=0.3.0
-  - pyyaml=5.1
-  - affine=2.2.2
-  - albumentations>0.2.3
-  - rio-cogeo=1.0.0
+# All of the below are pre-installed and don't need to be explicitly referenced
+#  - python=3.6
+#  - pip=19.0
+#  - shapely=1.6.4
+#  - fiona=1.8.6
+#  - pandas=0.24.2
+#  - geopandas>=0.4.1
+#  - opencv=3.4.4
+#  - numpy=1.16.3
+#  - gdal=2.4.1
+#  - tqdm=4.31.1
+#  - matplotlib=3.1.0
+#  - rtree=0.8.3
+#  - urllib3=1.24.3
+#  - networkx=2.3
+#  - rasterio=1.0.23
+#  - scipy=1.2.1
+#  - scikit-image=0.15.0
+#  - tensorflow=1.13.1
+#  - pytorch=1.1.0
+#  - torchvision=0.3.0
+#  - pyyaml=5.1
+#  - affine=2.2.2
+#  - albumentations>0.2.3
+#  - rio-cogeo=1.0.0
   - pip:
 # Add your pip dependencies (taken directly from pypi) here, we'll use the version of python and pip installed above
     - six>=1.12.0


### PR DESCRIPTION
This PR replaces anaconda with miniconda, dramatically reducing disk utilization to improve buildtime/runtime performance of the anaconda based IPA images. We also removed the tini dependency which is not required for our use.

This reduces the anaconda base image by ~2.97GB, which further reduces later layer image sizes by being a necessary per-requesite layer.