### PR TITLE
ALGO-596 tensorrt support

### DIFF
--- a/libraries/tensorrt-6.0-cuda10.0/Dockerfile
+++ b/libraries/tensorrt-6.0-cuda10.0/Dockerfile
@@ -1,4 +1,4 @@
 # This is a unique packageset in which it requires both a specific version of CUDA, and a version of Ubuntu as well.
 COPY --chown=0:0 tensorrt-6.0-cuda10.0/context/install /tmp/install
-RUN wget -O - https://james-s-public.s3.amazonaws.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz | (cd /tmp && tar zxf -)
+RUN wget -O - https://algorithmia-assets.s3.amazonaws.com/algo_dependencies/tensorrt/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz | (cd /tmp && tar zxf -)
 RUN sh /tmp/install 6.0.1.5

--- a/libraries/tensorrt-6.0-cuda10.0/Dockerfile
+++ b/libraries/tensorrt-6.0-cuda10.0/Dockerfile
@@ -1,0 +1,4 @@
+# This is a unique packageset in which it requires both a specific version of CUDA, and a version of Ubuntu as well.
+COPY --chown=0:0 tensorrt-6.0-cuda10.0/context/install /tmp/install
+RUN wget -O - https://james-s-public.s3.amazonaws.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.0.cudnn7.6.tar.gz | (cd /tmp && tar zxf -)
+RUN sh /tmp/install 6.0.1.5

--- a/libraries/tensorrt-6.0-cuda10.0/context/install
+++ b/libraries/tensorrt-6.0-cuda10.0/context/install
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cp -LrR /tmp/TensorRT-$1/targets/x86_64-linux-gnu/lib/* /usr/lib/x86_64-linux-gnu/
+pip install /tmp/TensorRT-$1/python/tensorrt-$1-cp37-none-linux_x86_64.whl
+pip install /tmp/TensorRT-$1/uff/uff-0.6.5-py2.py3-none-any.whl

--- a/templates/tensorrt-6.0-cuda10.0/algorithmia.conf
+++ b/templates/tensorrt-6.0-cuda10.0/algorithmia.conf
@@ -1,0 +1,5 @@
+{
+    "username": "__USER__",
+    "algoname": "__ALGO__",
+    "langauge": "python3.7"
+}

--- a/templates/tensorrt-6.0-cuda10.0/requirements.txt
+++ b/templates/tensorrt-6.0-cuda10.0/requirements.txt
@@ -4,5 +4,5 @@ numpy>=1.16.0,<2.0
 pycuda==2018.1.1
 Pillow>=5.2.0
 wget>=3.2
-tensorrt==6.0.1.5 # unchangable
+tensorrt==6.0.1.5 #Not changable by the user, this is implemented at the service level - if you desire a different version, please contact support.
 onnx==1.5.0

--- a/templates/tensorrt-6.0-cuda10.0/requirements.txt
+++ b/templates/tensorrt-6.0-cuda10.0/requirements.txt
@@ -1,0 +1,8 @@
+algorithmia>=1.0.0,<2.0
+six
+numpy>=1.16.0,<2.0
+pycuda==2018.1.1
+Pillow>=5.2.0
+wget>=3.2
+tensorrt==6.0.1.5 # unchangable
+onnx==1.5.0

--- a/templates/tensorrt-6.0-cuda10.0/src/__ALGO__.py
+++ b/templates/tensorrt-6.0-cuda10.0/src/__ALGO__.py
@@ -7,9 +7,9 @@ from PIL import Image
 # For more details, see algorithmia.com/developers/algorithm-development/languages
 
 SIMD_ALGO = "util/SmartImageDownloader/0.2.14"
-MODEL_PATH = "data://zeryx/collection/mobilenetv2-1.0.onnx"
+MODEL_PATH = "data://algorithmiahq/collection/mobilenetv2-1.0.onnx"
 
-client = Algorithmia.client("simP1oZ9sfF7c1cBrYUQ08iBtdP1")
+client = Algorithmia.client()
 trt_engine = load(client, MODEL_PATH)
 
 

--- a/templates/tensorrt-6.0-cuda10.0/src/__ALGO__.py
+++ b/templates/tensorrt-6.0-cuda10.0/src/__ALGO__.py
@@ -1,0 +1,62 @@
+import Algorithmia
+import numpy as np
+import os
+from .auxillary import load, allocate_buffers, do_inference
+from PIL import Image
+# API calls will begin at the apply() method, with the request body passed as 'input'
+# For more details, see algorithmia.com/developers/algorithm-development/languages
+
+SIMD_ALGO = "util/SmartImageDownloader/0.2.14"
+MODEL_PATH = "data://zeryx/collection/mobilenetv2-1.0.onnx"
+
+client = Algorithmia.client("simP1oZ9sfF7c1cBrYUQ08iBtdP1")
+trt_engine = load(client, MODEL_PATH)
+
+
+def preprocess(image_path):
+    image = Image.open(image_path)
+    image_data = np.array(image).transpose(2, 0, 1)
+    # convert the input data into the float32 input
+    img_data = image_data.astype('float32')
+    img_data = img_data.reshape(1, 3, 224, 224)
+
+    #normalize
+    mean_vec = np.array([0.485, 0.456, 0.406])
+    stddev_vec = np.array([0.229, 0.224, 0.225])
+    norm_img_data = np.zeros(img_data.shape).astype('float32')
+    for i in range(img_data.shape[0]):
+        norm_img_data[i,:,:] = (img_data[i,:,:]/255 - mean_vec[i]) / stddev_vec[i]
+    return norm_img_data
+
+def softmax(x):
+    x = x.reshape(-1)
+    e_x = np.exp(x - np.max(x))
+    return e_x / e_x.sum(axis=0)
+
+def postprocess(result):
+    return softmax(np.array(result)).tolist()
+
+
+def infer(image_data):
+    inputs, outputs, bindings, stream = allocate_buffers(trt_engine)
+    inputs[0].host = image_data
+    with trt_engine.create_execution_context() as context:
+        trt_outputs = do_inference(context, bindings=bindings, inputs=inputs, outputs=outputs, stream=stream)
+    print(trt_outputs)
+    return trt_outputs
+
+
+
+def get_image(url, shape):
+    output_url = client.algo(SIMD_ALGO).pipe({'image': str(url), "resize": shape}).result['savePath'][0]
+    temp_file = client.file(output_url).getFile().name
+    os.rename(temp_file, temp_file + '.' + output_url.split('.')[-1])
+    local_file = temp_file + '.' + output_url.split('.')[-1]
+    return local_file
+
+def apply(input):
+    image = get_image(input, {"height": 224, "width": 224})
+    image_data = preprocess(image)
+    trt_output = infer(image_data)
+    res = postprocess(trt_output)
+    return res

--- a/templates/tensorrt-6.0-cuda10.0/src/__ALGO__.py
+++ b/templates/tensorrt-6.0-cuda10.0/src/__ALGO__.py
@@ -7,10 +7,10 @@ from PIL import Image
 # For more details, see algorithmia.com/developers/algorithm-development/languages
 
 SIMD_ALGO = "util/SmartImageDownloader/0.2.14"
-MODEL_PATH = "data://algorithmiahq/collection/mobilenetv2-1.0.onnx"
+MODEL_PATH = "https://algorithmia-assets.s3.amazonaws.com/onnx/mobilenetv2-1.0.onnx"
 
 client = Algorithmia.client()
-trt_engine = load(client, MODEL_PATH)
+trt_engine = load(MODEL_PATH)
 
 
 def preprocess(image_path):

--- a/templates/tensorrt-6.0-cuda10.0/src/__ALGO___test.py
+++ b/templates/tensorrt-6.0-cuda10.0/src/__ALGO___test.py
@@ -1,0 +1,7 @@
+from __ALGO__ import apply
+
+def test_algorithm():
+    input = {"matrix_a": [[0, 1], [1, 0]], "matrix_b": [[25, 25], [11, 11]]}
+    result = apply(input)
+    assert result == {"product": [[11., 11.], [25., 25.]]}
+

--- a/templates/tensorrt-6.0-cuda10.0/src/auxillary.py
+++ b/templates/tensorrt-6.0-cuda10.0/src/auxillary.py
@@ -1,6 +1,7 @@
 import tensorrt as trt
 import onnx
 import os
+import wget
 import pycuda.driver as cuda
 import pycuda.autoinit
 import tensorrt as trt
@@ -42,8 +43,11 @@ def allocate_buffers(engine):
     return inputs, outputs, bindings, stream
 
 
-def load(client, model_path):
-    local_path = client.file(model_path).getFile().name
+def load(model_path):
+    out_dir = "/tmp"
+    filename = model_path.split('/')[-1]
+    local_path = "{}/{}".format(out_dir, filename)
+    wget.download(model_path, local_path)
 
     """Takes an ONNX file and creates a TensorRT engine to run inference with"""
     with trt.Builder(TRT_LOGGER) as builder, builder.create_network() as network, \

--- a/templates/tensorrt-6.0-cuda10.0/src/auxillary.py
+++ b/templates/tensorrt-6.0-cuda10.0/src/auxillary.py
@@ -1,0 +1,79 @@
+import tensorrt as trt
+import onnx
+import os
+import pycuda.driver as cuda
+import pycuda.autoinit
+import tensorrt as trt
+
+TRT_LOGGER = trt.Logger()
+
+
+class HostDeviceMem(object):
+    def __init__(self, host_mem, device_mem):
+        self.host = host_mem
+        self.device = device_mem
+
+    def __str__(self):
+        return "Host:\n" + str(self.host) + "\nDevice:\n" + str(self.device)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+# Allocates all buffers required for an engine, i.e. host/device inputs/outputs.
+def allocate_buffers(engine):
+    inputs = []
+    outputs = []
+    bindings = []
+    stream = cuda.Stream()
+    for binding in engine:
+        size = trt.volume(engine.get_binding_shape(binding)) * engine.max_batch_size
+        dtype = trt.nptype(engine.get_binding_dtype(binding))
+        # Allocate host and device buffers
+        host_mem = cuda.pagelocked_empty(size, dtype)
+        device_mem = cuda.mem_alloc(host_mem.nbytes)
+        # Append the device buffer to device bindings.
+        bindings.append(int(device_mem))
+        # Append to the appropriate list.
+        if engine.binding_is_input(binding):
+            inputs.append(HostDeviceMem(host_mem, device_mem))
+        else:
+            outputs.append(HostDeviceMem(host_mem, device_mem))
+    return inputs, outputs, bindings, stream
+
+
+def load(client, model_path):
+    local_path = client.file(model_path).getFile().name
+
+    """Takes an ONNX file and creates a TensorRT engine to run inference with"""
+    with trt.Builder(TRT_LOGGER) as builder, builder.create_network() as network, \
+            trt.OnnxParser(network, TRT_LOGGER) as parser:
+        builder.max_workspace_size = 1 << 30  # 1GB
+        builder.max_batch_size = 1
+        builder.fp16_mode = True
+        # Parse model file
+        if not os.path.exists(local_path):
+            print('ONNX file {} not found, please run yolov3_to_onnx.py first to generate it.'.format(model_path))
+            exit(0)
+        print('Loading ONNX file from path {}...'.format(local_path))
+        with open(local_path, 'rb') as model:
+            print('Beginning ONNX file parsing')
+            parser.parse(model.read())
+        print('Completed parsing of ONNX file')
+        print('Building an engine from file {}; this may take a while...'.format(model_path))
+        engine = builder.build_cuda_engine(network)
+        print("Completed creating Engine")
+        return engine
+
+    # This function is generalized for multiple inputs/outputs.
+    # inputs and outputs are expected to be lists of HostDeviceMem objects.
+def do_inference(context, bindings, inputs, outputs, stream, batch_size=1):
+    # Transfer input data to the GPU.
+    [cuda.memcpy_htod_async(inp.device, inp.host, stream) for inp in inputs]
+    # Run inference.
+    context.execute_async(batch_size=batch_size, bindings=bindings, stream_handle=stream.handle)
+    # Transfer predictions back from the GPU.
+    [cuda.memcpy_dtoh_async(out.host, out.device, stream) for out in outputs]
+    # Synchronize the stream
+    stream.synchronize()
+    return [out.host for out in outputs]


### PR DESCRIPTION
added and verified tensorRT support with onnx template.

My validator tool currently doesn't support gpus or algo keys, so please run the following command to build the package:
`./tools/packageset_validator.py -b nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04 -g python3 -s python37 -d tensorrt-6.0-cuda10.0 -t dependency -n tensorrt-6.0-cuda10.0`
and then when that fails, run the final image with the following
`docker run -it --runtime=nvidia -p 9999:9999 -e ALGORITHMIA_API_KEY='YOUR_API_KEY_HERE' 773e57916fcb`, replacing `773e57916fcb` with your final image hash as an output from `docker images`.
**Requires NVIDIA Docker to be installed and configured to test**
