### PR TITLE
Add quotes to requirements.txt for pytorch 1.1.x & 1.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: rust
+rust:
+  - 1.3.90
 
 script:
   - cargo build --release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.3.90
+  - 1.39.0
 
 script:
   - cargo build --release

--- a/libraries/pytorch-1.1.x/Dockerfile
+++ b/libraries/pytorch-1.1.x/Dockerfile
@@ -1,2 +1,2 @@
 RUN pip install numpy==1.16.0
-RUN pip install torch>=1.1.0,<1.2.0
+RUN pip install "torch>=1.1.0,<1.2.0"

--- a/libraries/pytorch-1.2.x/Dockerfile
+++ b/libraries/pytorch-1.2.x/Dockerfile
@@ -1,2 +1,2 @@
 RUN pip install numpy==1.16.0
-RUN pip install torch>=1.2.0,<1.3.0
+RUN pip install "torch>=1.2.0,<1.3.0"


### PR DESCRIPTION
Fixing the syntax errors in `requirements.txt` for the `pytorch-1.1.x` & `pytorch-1.2.x` packagesets.