### PR TITLE
ALGO-737-tensorflow-2.1 support

### DIFF
--- a/libraries/tensorflow-gpu-2.1/Dockerfile
+++ b/libraries/tensorflow-gpu-2.1/Dockerfile
@@ -1,0 +1,2 @@
+RUN pip install keras==2.3.1
+RUN pip install "tensorflow-gpu>=2.1,<2.2"

--- a/templates/tensorflow-gpu-2.1/algorithmia.conf
+++ b/templates/tensorflow-gpu-2.1/algorithmia.conf
@@ -1,0 +1,5 @@
+{
+    "username": "__USER__",
+    "algoname": "__ALGO__",
+    "language": "python-3.x-1"
+}

--- a/templates/tensorflow-gpu-2.1/requirements.txt
+++ b/templates/tensorflow-gpu-2.1/requirements.txt
@@ -1,0 +1,3 @@
+algorithmia>=1.0.0,<2.0
+six
+tensorflow-gpu>=2.1,<2.2 # if you need a different version, please change this value - bear in mind that it may take longer to compile.

--- a/templates/tensorflow-gpu-2.1/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-2.1/src/__ALGO__.py
@@ -1,0 +1,63 @@
+import Algorithmia
+import tensorflow.keras.backend as K
+from tensorflow import convert_to_tensor
+import numpy as np
+
+"""
+Example Input:
+{
+    "matrix_a": [[0, 1], [1, 0]],
+    "matrix_b": [[25, 25], [11, 11]]
+}
+
+Expected Output:
+{
+    "product": [[11, 11], [25, 25]]
+}
+"""
+
+class InputObject:
+    def __init__(self, input_dict):
+        """
+        Creates an instance of the InputObject, which checks the format of data and throws exceptions if anything is
+        missing.
+        "matrix_a" and "matrix_b" must be the same shape.
+
+        :param A - Matrix A, converted from a json list into a keras Tensor.
+        :param B - Matrix B, converted from a json list into a keras Tensor.
+        """
+        if isinstance(input_dict, dict):
+            if {'matrix_a', 'matrix_b'} <= input_dict.keys():
+                self.A = convert(input_dict['matrix_a'])
+                self.B = convert(input_dict['matrix_b'])
+            else:
+                raise Exception("'matrix_a' and 'matrix_b' must be defined.")
+        else:
+            raise Exception('input must be a json object.')
+        if self.A.shape[-1] != self.B.shape[0]:
+            raise Exception('inner dimensions between A and B must be the same.\n A: {} B: {}'.format(self.A.shape[-1],
+                                                                                                      self.B.shape[0]))
+
+
+def convert(list_array):
+    """
+    Converts a json list into a keras Tensor object.
+    """
+    numpy_object = np.asarray(list_array, dtype=np.float)
+    tensor_object = convert_to_tensor(numpy_object)
+    return tensor_object
+
+def apply(input):
+    """
+    Calculates the dot product of two matricies using keras, with a tensorflow-gpu backend.
+    Returns the product as the output.
+    """
+    input = InputObject(input)
+
+    z = K.dot(input.A, input.B)
+    # Here you need to use K.eval() instead of z.eval() because this uses the backend session
+    K.eval(z)
+    z = K.get_value(z)
+    output = {'product': z.tolist()}
+    return output
+

--- a/templates/tensorflow-gpu-2.1/src/__ALGO___test.py
+++ b/templates/tensorflow-gpu-2.1/src/__ALGO___test.py
@@ -1,0 +1,7 @@
+from .__ALGO__ import apply
+
+
+def test_algorithm():
+    input = {"matrix_a": [[0, 1], [1, 0]], "matrix_b": [[25, 25], [11, 11]]}
+    result = apply(input)
+    assert result == {"product": [[11., 11.], [25., 25.]]}


### PR DESCRIPTION
PR to support tensorflow 2.1, test using the packageset_validator
## HOW TO TEST
`./tools/packageset_validator.py -g python3 -s python37 -d tensorflow-gpu-2.1 -t dependency -n tensorflow-gpu-2.1` once PIPE_INIT_COMPLETE is sent, send the following as input in another terminal:
`curl localhost:9999 -H 'Content-Type: application/json' -d '{"matrix_a": [[0, 1], [1, 0]],"matrix_b": [[25, 25], [11, 12]]}'`