### PR TITLE
ALGO-741 updating pipe to enable mojo pipeline

### DIFF
--- a/java/template/bin/pipe
+++ b/java/template/bin/pipe
@@ -2,4 +2,4 @@
 
 set -e
 
-java -cp /bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:target/dependencies/* com.algorithmia.Pipe
+java -cp "/bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:target/dependencies/*" com.algorithmia.Pipe

--- a/java/template/bin/pipe
+++ b/java/template/bin/pipe
@@ -2,4 +2,4 @@
 
 set -e
 
-java -cp /bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:/bin/javaLangpack/dependencies/gson-2.8.0.jar:/bin/javaLangpack/dependencies/commons-io-2.5.jar com.algorithmia.Pipe
+java -cp algorithmia-langpack-1.0-SNAPSHOT.jar:target/dependencies/* com.algorithmia.Pipe

--- a/java/template/bin/pipe
+++ b/java/template/bin/pipe
@@ -2,4 +2,4 @@
 
 set -e
 
-java -cp "/bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:target/dependencies/*" com.algorithmia.Pipe
+java -cp "/bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:/opt/algorithm/target/dependencies/*" com.algorithmia.Pipe

--- a/java/template/bin/pipe
+++ b/java/template/bin/pipe
@@ -2,4 +2,4 @@
 
 set -e
 
-java -cp algorithmia-langpack-1.0-SNAPSHOT.jar:target/dependencies/* com.algorithmia.Pipe
+java -cp /bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:target/dependencies/* com.algorithmia.Pipe


### PR DESCRIPTION
This change adjusts legacy java to enable mojo runtime backend support, required for the driverless AI pipeline.

For an example of what kind of algorithm this would enable: https://algorithmia.com/algorithms/zeryx/driverless_legacy/source