### PR TITLE
java/scala legacy fix

### DIFF
--- a/java/template/bin/pipe
+++ b/java/template/bin/pipe
@@ -2,4 +2,4 @@
 
 set -e
 
-java -cp "/bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:/opt/algorithm/target/dependencies/*" com.algorithmia.Pipe
+java -cp "/bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:/bin/javaLangpack/dependencies/gson-2.8.0.jar:/bin/javaLangpack/dependencies/commons-io-2.5.jar:/opt/algorithm/target/dependencies/*" com.algorithmia.Pipe

--- a/scala/template/bin/pipe
+++ b/scala/template/bin/pipe
@@ -2,4 +2,4 @@
 
 set -e
 
-java -cp /bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:/bin/javaLangpack/dependencies/gson-2.8.0.jar:/bin/javaLangpack/dependencies/commons-io-2.5.jar com.algorithmia.Pipe
+java -cp "/bin/javaLangpack/algorithmia-langpack-1.0-SNAPSHOT.jar:/bin/javaLangpack/dependencies/gson-2.8.0.jar:/bin/javaLangpack/dependencies/commons-io-2.5.jar:/opt/algorithm/target/dependencies/*" com.algorithmia.Pipe


### PR DESCRIPTION
knock on PR succeeding: https://github.com/algorithmiaio/langpacks/pull/124 as it was discovered our change introduced a potential bug that would effect users who delete critical parts of their pom.xml file.

As requested, updated the scala legacy /bin/pipe script to maintain equivalence with java legacy functionality.