### PR TITLE
ALGO-748 pytorch 1.4.x support

### DIFF
--- a/libraries/pytorch-1.4.x/Dockerfile
+++ b/libraries/pytorch-1.4.x/Dockerfile
@@ -1,0 +1,2 @@
+RUN pip install numpy==1.16.0
+RUN pip install "torch>=1.4.0,<1.5.0"

--- a/templates/pytorch-1.4.x/algorithmia.conf
+++ b/templates/pytorch-1.4.x/algorithmia.conf
@@ -1,0 +1,5 @@
+{
+    "username": "__USER__",
+    "algoname": "__ALGO__",
+    "language": "python-3.x-1"
+}

--- a/templates/pytorch-1.4.x/requirements.txt
+++ b/templates/pytorch-1.4.x/requirements.txt
@@ -1,0 +1,4 @@
+algorithmia>=1.0.0,<2.0
+six
+numpy>=1.16.0,<2.0
+torch>=1.4.0,<1.5.0 # you can use a different pytorch version version, however please bear in mind that it may take longer to compile and load.

--- a/templates/pytorch-1.4.x/src/__ALGO__.py
+++ b/templates/pytorch-1.4.x/src/__ALGO__.py
@@ -1,0 +1,56 @@
+import Algorithmia
+import torch as th
+
+"""
+Example Input:
+{
+    "matrix_a": [[0, 1], [1, 0]],
+    "matrix_b": [[25, 25], [11, 11]]
+}
+
+Expected Output:
+{
+    "product": [[11, 11], [25, 25]]
+}
+"""
+
+class InputObject:
+    def __init__(self, input_dict):
+        """
+        Creates an instance of the InputObject, which checks the format of data and throws exceptions if anything is
+        missing.
+        "matrix_a" and "matrix_b" must be the same shape.
+        :param A - Matrix A, converted from a json list into a torch cuda Tensor.
+        :param B - Matrix B, converted from a json list into a torch cuda Tensor.
+        """
+        if isinstance(input_dict, dict):
+            if {'matrix_a', 'matrix_b'} <= input_dict.keys():
+                self.A = convert(input_dict['matrix_a'])
+                self.B = convert(input_dict['matrix_b'])
+            else:
+                raise Exception("'matrix_a' and 'matrix_b' must be defined.")
+        else:
+            raise Exception('input must be a json object.')
+        if self.A.shape[-1] != self.B.shape[0]:
+            raise Exception('inner dimensions between A and B must be the same.\n A: {} B: {}'
+                .format(self.A.shape[-1], self.B.shape[0]))
+
+
+def convert(list_array):
+    """
+    Converts a json list into a torch Tensor object.
+    """
+    th_tensor = th.tensor(list_array).float()
+    gpu_tensor = th_tensor.cuda()
+    return gpu_tensor
+
+def apply(input):
+    """
+    Calculates the dot product of two matricies using pytorch, with a cudnn backend.
+    Returns the product as the output.
+    """
+    input = InputObject(input)
+    C = th.mm(input.A, input.B)
+    z = C.cpu().numpy().tolist()
+    output = {'product': z}
+    return output

--- a/templates/pytorch-1.4.x/src/__ALGO___test.py
+++ b/templates/pytorch-1.4.x/src/__ALGO___test.py
@@ -1,0 +1,7 @@
+from __ALGO__ import apply
+
+def test_algorithm():
+    input = {"matrix_a": [[0, 1], [1, 0]], "matrix_b": [[25, 25], [11, 11]]}
+    result = apply(input)
+    assert result == {"product": [[11., 11.], [25., 25.]]}
+


### PR DESCRIPTION
Adds pytorch 1.4.x support, to test run the following in a screen session:
`./tools/packageset_validator.py -g python3 -s python37 -d pytorch-1.4.x -t dependency -n pytorch-1.4.x`

The packageset_validator does not support passing nvidia device driver components today, however that's something we can add to fully ensure compatibility.