### PR TITLE
ALGO-XXX added firefox to installation settings, when users need ff support

### DIFF
--- a/libraries/selenium3.141.x-python/Dockerfile
+++ b/libraries/selenium3.141.x-python/Dockerfile
@@ -4,13 +4,17 @@ RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x
   tar -xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 -C /usr/local/share/ && \
   ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/
 
-# Chrome for Selenium
+# Chrome & Firefox for Selenium
 RUN apt-get update && \
   apt-get install unzip && \
   wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip && \
   unzip chromedriver_linux64.zip && \
   cp chromedriver /usr/local/share/ && \
   ln -s /usr/local/share/chromedriver /usr/local/bin/ && \
+  wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz && \
+  tar xf geckodriver-v0.26.0-linux64.tar.gz && \
+  cp geckodriver /usr/local/share/ && \
+  ln -s /usr/local/share/geckodriver /usr/local/bin && \
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y  chromium-browser firefox && \
   rm -rf /var/lib/apt/lists/*
 

--- a/libraries/selenium3.141.x-python/Dockerfile
+++ b/libraries/selenium3.141.x-python/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
   unzip chromedriver_linux64.zip && \
   cp chromedriver /usr/local/share/ && \
   ln -s /usr/local/share/chromedriver /usr/local/bin/ && \
-  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y  chromium-browser && \
+  DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y  chromium-browser firefox && \
   rm -rf /var/lib/apt/lists/*
 
 RUN pip install "selenium>=3.141.0,<3.142.0"


### PR DESCRIPTION
Looks like we're missing a dependency for when users try and run the selenium package set with firefox.
`libdbus-glib-1.so.2: cannot open shared object file: No such file or directory`
From the docs, it looks like we'll need to add firefox as a hard dependency to overcome this issue.