### PR TITLE
Use https for Maven Central resolver

### DIFF
--- a/scala/template/build.sbt
+++ b/scala/template/build.sbt
@@ -15,8 +15,6 @@ mainClass in Compile := Some("algorithmia.Main")
 
 val repoUrl = System.getProperty("repo.url", "http://git.algorithmia.com")
 
-resolvers += "Maven Central" at "https://repo1.maven.org/maven2/org/"
-
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= Seq(

--- a/scala/template/build.sbt
+++ b/scala/template/build.sbt
@@ -15,7 +15,7 @@ mainClass in Compile := Some("algorithmia.Main")
 
 val repoUrl = System.getProperty("repo.url", "http://git.algorithmia.com")
 
-resolvers += "Maven Central" at "http://repo1.maven.org/maven2/org/"
+resolvers += "Maven Central" at "https://repo1.maven.org/maven2/org/"
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 


### PR DESCRIPTION
A 20.0 bugbash cluster (https://algo-200rc1.algo.click) is showing the following error when you try to build Scala algorithms:

```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
Error during sbt execution: Invalid URL specified for 'my-ivy-proxy-releases': no protocol: None
```

I _think_ this may have to do with the Maven switching to https issue we had in January. I'm not sure if this is the problem, or if my changes here will solve it so I wanted to get some feedback from the team and and open to any testing strategies.