### PR TITLE
Limit tf gpu usage

### DIFF
--- a/templates/tensorflow-gpu-1.12/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-1.12/src/__ALGO__.py
@@ -1,5 +1,7 @@
 import Algorithmia
 import tensorflow.keras.backend as K
+from tensorflow.keras.backend import set_session
+from tensorflow import ConfigProto, Session
 from tensorflow import convert_to_tensor
 import numpy as np
 
@@ -15,6 +17,13 @@ Expected Output:
     "product": [[11, 11], [25, 25]]
 }
 """
+
+# Configure Tensorflow to only use up to 30% of the GPU.
+config = ConfigProto()
+config.gpu_options.allow_growth=True
+config.gpu_options.per_process_gpu_memory_fraction = 0.30
+sess = Session(config=config)
+set_session(sess)
 
 class InputObject:
     def __init__(self, input_dict):

--- a/templates/tensorflow-gpu-1.13/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-1.13/src/__ALGO__.py
@@ -1,5 +1,7 @@
 import Algorithmia
 import tensorflow.keras.backend as K
+from tensorflow.keras.backend import set_session
+from tensorflow import ConfigProto, Session
 from tensorflow import convert_to_tensor
 import numpy as np
 
@@ -15,6 +17,13 @@ Expected Output:
     "product": [[11, 11], [25, 25]]
 }
 """
+
+# Configure Tensorflow to only use up to 30% of the GPU.
+config = ConfigProto()
+config.gpu_options.allow_growth=True
+config.gpu_options.per_process_gpu_memory_fraction = 0.30
+sess = Session(config=config)
+set_session(sess)
 
 class InputObject:
     def __init__(self, input_dict):

--- a/templates/tensorflow-gpu-1.14/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-1.14/src/__ALGO__.py
@@ -1,5 +1,7 @@
 import Algorithmia
 import tensorflow.keras.backend as K
+from tensorflow.keras.backend import set_session
+from tensorflow import ConfigProto, Session
 from tensorflow import convert_to_tensor
 import numpy as np
 
@@ -15,6 +17,13 @@ Expected Output:
     "product": [[11, 11], [25, 25]]
 }
 """
+
+# Configure Tensorflow to only use up to 30% of the GPU.
+config = ConfigProto()
+config.gpu_options.allow_growth=True
+config.gpu_options.per_process_gpu_memory_fraction = 0.30
+sess = Session(config=config)
+set_session(sess)
 
 class InputObject:
     def __init__(self, input_dict):

--- a/templates/tensorflow-gpu-2.0/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-2.0/src/__ALGO__.py
@@ -1,6 +1,7 @@
 import Algorithmia
 import tensorflow.keras.backend as K
 from tensorflow import convert_to_tensor
+import tensorflow as tf
 import numpy as np
 
 """
@@ -15,6 +16,11 @@ Expected Output:
     "product": [[11, 11], [25, 25]]
 }
 """
+
+# Configure Tensorflow to only use up to 30% of the GPU.
+gpus = tf.config.experimental.list_physical_devices('GPU')
+tf.config.experimental.set_memory_growth(gpus[0], True)
+tf.config.experimental.set_virtual_device_configuration(gpus[0], [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=3432)])
 
 class InputObject:
     def __init__(self, input_dict):

--- a/templates/tensorflow-gpu-2.1/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-2.1/src/__ALGO__.py
@@ -1,6 +1,7 @@
 import Algorithmia
 import tensorflow.keras.backend as K
 from tensorflow import convert_to_tensor
+import tensorflow as tf
 import numpy as np
 
 """
@@ -15,6 +16,11 @@ Expected Output:
     "product": [[11, 11], [25, 25]]
 }
 """
+
+# Configure Tensorflow to only use up to 30% of the GPU.
+gpus = tf.config.experimental.list_physical_devices('GPU')
+tf.config.experimental.set_memory_growth(gpus[0], True)
+tf.config.experimental.set_virtual_device_configuration(gpus[0], [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=3432)])
 
 class InputObject:
     def __init__(self, input_dict):


### PR DESCRIPTION
Changed the tensorflow 1.x & 2.x templates to limits GPU usage up to 30% of the GPU.

To test, you can copy over the hello world templates on PROD, compile & try to run the example input.

I've verified the new templates on all packagesets except for tensorflow 2.1.x.

It seems that tf-2.1.x doesn't support CUDA 10.2, it specifically requires CUDA 10.1, so you'll get an error when you run the new template.

I've made a separate PR for that on `stagetools` which will make `tf-2.1.x` use `CUDA 10.1` instead of `CUDA 10.2` here: https://github.com/algorithmiaio/stagetools/pull/1005

Relevant Github issue can be found [here](https://github.com/tensorflow/tensorflow/issues/34759).