### PR TITLE
Attempt to fixup the last of the compile errors via guess and check

### DIFF
--- a/src/langrunner.rs
+++ b/src/langrunner.rs
@@ -226,7 +226,7 @@ impl LangRunnerProcess {
                 match line_result {
                     Ok(line) => {
                         match arc_stderr_buf.lock() {
-                            Ok(mut lines) => lines.push_str(&line),
+                            Ok(mut lines) => lines.push_str(&line), // TODO: Add newline character
 						    Err(err) => error!("{} {} Failed to get lock on stderr buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOERR", req_id, line);
@@ -258,7 +258,7 @@ impl LangRunnerProcess {
                         break;
                     } else {
                         match arc_stdout_buf.lock() {
-                            Ok(mut lines) => lines.push_str(&line),
+                            Ok(mut lines) => lines.push_str(&line), // TODO: Add newline character
 						    Err(err) => error!("{} {} Failed to get lock on stdout buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOOUT", req_id, &line);

--- a/src/langrunner.rs
+++ b/src/langrunner.rs
@@ -149,7 +149,8 @@ impl LangRunner {
             };
 
             // Augment output with duration and stdout
-            runner_state.into_message(duration)
+            let stdio = self.take_stdio();
+            runner_state.into_message(duration, Some(stdio.0), Some(stdio.1))
         };
 
         // We are now done with a request, we can set the request_id to none

--- a/src/langrunner.rs
+++ b/src/langrunner.rs
@@ -226,7 +226,10 @@ impl LangRunnerProcess {
                 match line_result {
                     Ok(line) => {
                         match arc_stderr_buf.lock() {
-                            Ok(mut lines) => lines.push_str(&line), // TODO: Add newline character
+                            Ok(mut lines) => {
+                                lines.push_str(&line);
+                                lines.push('\n');
+                            }
 						    Err(err) => error!("{} {} Failed to get lock on stderr buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOERR", req_id, line);
@@ -258,7 +261,10 @@ impl LangRunnerProcess {
                         break;
                     } else {
                         match arc_stdout_buf.lock() {
-                            Ok(mut lines) => lines.push_str(&line), // TODO: Add newline character
+                            Ok(mut lines) => {
+                                lines.push_str(&line);
+                                lines.push('\n');
+                            }
 						    Err(err) => error!("{} {} Failed to get lock on stdout buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOOUT", req_id, &line);

--- a/src/langserver.rs
+++ b/src/langserver.rs
@@ -83,8 +83,8 @@ impl LangServer {
                     if let Some(code) = status {
                         info!("{} {} LangServer monitor thread detected exit: {}", LOG_IDENTIFIER, "-", code);
                         if let Some(ref notifier) = notify_exited {
-                            let err = Error::UnexpectedExit(code, stdio.0, stdio.1);
-                            let message = StatusMessage::failure(err, Duration::new(0,0));
+                            let err = Error::UnexpectedExit(code, stdio.0.clone(), stdio.1.clone());
+                            let message = StatusMessage::failure(err, Duration::new(0,0), Some(stdio.0.clone()), Some(stdio.1.clone()));
                             let _ = notifier.notify(message, None);
                         }
                         if !is_async {

--- a/src/message.rs
+++ b/src/message.rs
@@ -29,10 +29,10 @@ pub enum RunnerMessage {
 #[derive(Serialize)]
 pub struct Metadata {
     pub duration: f64,
-    //#[serde(skip_serializing_if="Option::is_none")]
-    //pub stdout: Option<String>,
-    //#[serde(skip_serializing_if="Option::is_none")]
-    //pub stderr: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub stderr: Option<String>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub content_type: Option<String>,
 }
@@ -51,35 +51,37 @@ pub struct StatusMessage {
 }
 
 impl Metadata {
-    fn new(duration: Duration, content_type: Option<String>)
+    fn new(duration: Duration, content_type: Option<String>, stdout: Option<String>, stderr: Option<String>)
         -> Metadata {
         let duration_float = duration.as_secs() as f64 + (duration.subsec_nanos() as f64 / 1_000_000_000f64);
         Metadata {
             duration: duration_float,
             content_type: content_type,
+            stdout: stdout,
+            stderr: stderr,
         }
     }
 }
 
 impl RunnerState {
-    pub fn into_message(self, duration: Duration) -> RunnerMessage {
+    pub fn into_message(self, duration: Duration, stdout: Option<String>, stderr: Option<String>) -> RunnerMessage {
         match self {
             RunnerState::Completed(RunnerOutput::Success{ result, metadata }) => {
                 RunnerMessage::Success{
                     result: result,
-                    metadata: Metadata::new(duration, Some(metadata.content_type)),
+                    metadata: Metadata::new(duration, Some(metadata.content_type), stdout, stderr),
                 }
             }
             RunnerState::Completed(RunnerOutput::Failure{ error }) => {
                 RunnerMessage::Failure {
                     error: error,
-                    metadata: Metadata::new(duration, None),
+                    metadata: Metadata::new(duration, None, stdout, stderr),
                 }
             }
             RunnerState::Exited(err) => {
                 RunnerMessage::Failure {
                     error: ErrorMessage::exit(err),
-                    metadata: Metadata::new(duration, None),
+                    metadata: Metadata::new(duration, None, stdout, stderr),
                 }
             }
         }
@@ -99,7 +101,7 @@ impl RunnerMessage {
 }
 
 impl StatusMessage {
-    fn new(health_status: HealthStatus, load_time: Duration) -> StatusMessage {
+    fn new(health_status: HealthStatus, load_time: Duration, stdout: Option<String>, stderr: Option<String>) -> StatusMessage {
         let (status, error) = match health_status {
             HealthStatus::Success => ("Successful", None),
             HealthStatus::Failure(err) => ("Failed", Some(err)),
@@ -111,15 +113,17 @@ impl StatusMessage {
             metadata: Metadata {
                 duration: load_time.as_secs() as f64 + (load_time.subsec_nanos() as f64 / 1_000_000_000f64),
                 content_type: None,
+                stdout: stdout,
+                stderr: stderr,
             }
         }
     }
 
-    pub fn success(duration: Duration) -> StatusMessage {
-        StatusMessage::new(HealthStatus::Success, duration)
+    pub fn success(duration: Duration, stdout: Option<String>, stderr: Option<String>) -> StatusMessage {
+        StatusMessage::new(HealthStatus::Success, duration, stdout, stderr)
     }
 
-    pub fn failure(err: Error, duration: Duration) -> StatusMessage {
-        StatusMessage::new(HealthStatus::Failure(err), duration)
+    pub fn failure(err: Error, duration: Duration, stdout: Option<String>, stderr: Option<String>) -> StatusMessage {
+        StatusMessage::new(HealthStatus::Failure(err), duration, stdout, stderr)
     }
 }


### PR DESCRIPTION
This seems to get the information plumbed through, the error message still shows up as `exited with code 1` but the stderr/stdout get populated and we've previously had code that will scan for that one error message and instead report back stderr.

My thought is that it could make sense to just tack the stderr/stdout directly to the `error message` during unexpected exit but this at least solves the immediate problem (with a few modifications in other components)