### PR TITLE
Exit langserver after sending notification in the event that the algorithm process exits

### DIFF
--- a/src/langserver.rs
+++ b/src/langserver.rs
@@ -60,10 +60,6 @@ impl LangServer {
     // Monitor runner - exit if exit is encountered
     // Since this needs a lock on the runner, it won't run while we're calling the algorithm
     fn monitor_runner(&self, notify_exited: Option<Notifier>) {
-        let is_async = match self.mode {
-            LangServerMode::Sync => false,
-            LangServerMode::Async(..) => true,
-        };
         let watched_runner = self.runner.clone();
         let watched_delete_signal = self.delete_signalled.clone();
         thread::spawn(move || {
@@ -87,11 +83,7 @@ impl LangServer {
                             let message = StatusMessage::failure(err, Duration::new(0,0), Some(stdio.0.clone()), Some(stdio.1.clone()));
                             let _ = notifier.notify(message, None);
                         }
-                        if !is_async {
-                            process::exit(code);
-                        } else {
-                            break;
-                        }
+                        process::exit(code);
                     }
                 } else {
                     info!("{} {} Not sending status update on delete due to explicit delete", LOG_IDENTIFIER, "-");


### PR DESCRIPTION
Apparently this used to be handled externally - https://github.com/algorithmiaio/langpacks/commit/519859017443d2f6d6dd79962a447da74c94cb8c 

But that is no longer the case.  In a more abstract sense exiting langserver when the algorithm process is the only logical thing to do since it can't respond to any more API requests.

Validated that the errant behavior seen over the weekend no longer occurs.