### PR TITLE
Fixup stdio reporting when the algorithm ends up exiting the process 

### DIFF
--- a/src/langrunner.rs
+++ b/src/langrunner.rs
@@ -149,6 +149,8 @@ impl LangRunner {
             };
 
             // Augment output with duration and stdout
+            // NB: This might yield empty strings if the stdio was already consumed, it's up to
+            // runner_state.into_message to do the right thing
             let stdio = self.take_stdio();
             runner_state.into_message(duration, Some(stdio.0), Some(stdio.1))
         };
@@ -230,7 +232,7 @@ impl LangRunnerProcess {
                                 lines.push_str(&line);
                                 lines.push('\n');
                             }
-						    Err(err) => error!("{} {} Failed to get lock on stderr buffer: {}", LOG_IDENTIFIER, req_id, err),
+                            Err(err) => error!("{} {} Failed to get lock on stderr buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOERR", req_id, line);
                     },
@@ -265,7 +267,7 @@ impl LangRunnerProcess {
                                 lines.push_str(&line);
                                 lines.push('\n');
                             }
-						    Err(err) => error!("{} {} Failed to get lock on stdout buffer: {}", LOG_IDENTIFIER, req_id, err),
+                            Err(err) => error!("{} {} Failed to get lock on stdout buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOOUT", req_id, &line);
                     }
@@ -288,7 +290,7 @@ impl LangRunnerProcess {
                     Ok(line) => {
                         match arc_stdout_buf.lock() {
                             Ok(mut lines) => lines.push_str(&line),
-						    Err(err) => error!("{} {} Failed to get lock on stdout buffer: {}", LOG_IDENTIFIER, req_id, err),
+                            Err(err) => error!("{} {} Failed to get lock on stdout buffer: {}", LOG_IDENTIFIER, req_id, err),
                         }
                         info!("{} {} {}", "ALGOOUT", req_id, line);
                     }


### PR DESCRIPTION
since we read stdio multiple times which will result in empty strings being reported back

Confirmed locally that this will now do the correct thing in the event of a system.exit(1) inside of algorithm execution.  it's much more difficult to test the async load failure message locally so will validate that in cluster tomorrow prior to final merge.  The error stuff is really awkward and I'm not sure there's a better approach since Error is not clone-able (see https://github.com/algorithmiaio/langpacks/pull/140/files#r416299280).  Also the fact that stdio is only read for UnexpectedExit and nothing else contributes to this being awkward among other things but... whatever.