### PR TITLE
add display names to languages config file

### DIFF
--- a/languages/anaconda3/config.json
+++ b/languages/anaconda3/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "Anaconda",
     "artifacts": [
       {"source":"/home/algo/.cache", "destination":"/home/algo/.cache/"},
       {"source":"/home/algo/anaconda_environment", "destination": "/home/algo/anaconda_environment/"},

--- a/languages/anaconda3/config.json
+++ b/languages/anaconda3/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Anaconda",
+    "display_name": "Anaconda 3.5x",
     "artifacts": [
       {"source":"/home/algo/.cache", "destination":"/home/algo/.cache/"},
       {"source":"/home/algo/anaconda_environment", "destination": "/home/algo/anaconda_environment/"},

--- a/languages/csharp-dotnet-core2/config.json
+++ b/languages/csharp-dotnet-core2/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "C#",
+    "display_name": "C# .NET Core 2.x+",
     "artifacts": [
         {"source":"/opt/algorithm/bin/Release/*/*", "destination":"/opt/algorithm/"},
         {"source":"/opt/algorithm/resources", "destination":"/opt/algorithm/resources/"},

--- a/languages/csharp-dotnet-core2/config.json
+++ b/languages/csharp-dotnet-core2/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "C#",
     "artifacts": [
         {"source":"/opt/algorithm/bin/Release/*/*", "destination":"/opt/algorithm/"},
         {"source":"/opt/algorithm/resources", "destination":"/opt/algorithm/resources/"},

--- a/languages/java11/config.json
+++ b/languages/java11/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "Java 11",
     "artifacts": [
         {"source":"/opt/algorithm/target/*.jar", "destination":"/opt/algorithm/target/algorithm.jar"},
         {"source":"/opt/algorithm/target/lib", "destination":"/opt/algorithm/target/lib/"}

--- a/languages/java11/config.json
+++ b/languages/java11/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Java 11",
+    "display_name": "Java OpenJDK 11.0",
     "artifacts": [
         {"source":"/opt/algorithm/target/*.jar", "destination":"/opt/algorithm/target/algorithm.jar"},
         {"source":"/opt/algorithm/target/lib", "destination":"/opt/algorithm/target/lib/"}

--- a/languages/python2/config.json
+++ b/languages/python2/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "Python 2.x",
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
         {"source":"/opt/algorithm", "destination":"/opt/algorithm/"}

--- a/languages/python3/config.json
+++ b/languages/python3/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "Python 3.x",
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
         {"source":"/opt/algorithm", "destination":"/opt/algorithm/"}

--- a/languages/r36/config.json
+++ b/languages/r36/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "R",
     "artifacts": [
       {"source":"/opt/algorithm", "destination":"/opt/algorithm/"},
       {"source":"/usr/local/lib/R/site-library", "destination":"/usr/local/lib/R/site-library/"}

--- a/languages/r36/config.json
+++ b/languages/r36/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "R",
+    "display_name": "R 3.6.x",
     "artifacts": [
       {"source":"/opt/algorithm", "destination":"/opt/algorithm/"},
       {"source":"/usr/local/lib/R/site-library", "destination":"/usr/local/lib/R/site-library/"}

--- a/languages/scala-2/config.json
+++ b/languages/scala-2/config.json
@@ -1,4 +1,5 @@
 {
+    "display_name": "Scala",
     "artifacts": [
       {"source":"/opt/algorithm/target/universal/stage", "destination":"/opt/algorithm/stage/"}
     ]

--- a/languages/scala-2/config.json
+++ b/languages/scala-2/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Scala",
+    "display_name": "Scala 2.x & sbt 1.3.x",
     "artifacts": [
       {"source":"/opt/algorithm/target/universal/stage", "destination":"/opt/algorithm/stage/"}
     ]


### PR DESCRIPTION
This ticket https://algorithmia.atlassian.net/browse/ALGOENV-160 requires `display_name` to be added the `config.json` of our languages. Aside from Python, Java was the only one I thought would be helpful to have version displayed, but I can change that if people think it'd be better for java to not have it, or for other languages to also have it.