### PR TITLE
Scripts need to be copied from the build's context directory into the expected location

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -15,6 +15,8 @@ RUN /usr/local/bin/algorithmia-build
 {% else %}
 # customize-container.sh runs as root, then switches to user of less privilege
 USER root
+COPY mounted-scripts /opt/algorithmiaio/mounted-scripts
+COPY ca-certificates /opt/algorithmia
 RUN /opt/algorithmiaio/mounted-scripts/customize-container.sh algo /usr/local/bin/algorithmia-build
 {% endif %}
 


### PR DESCRIPTION
Builds were failing due to `/opt/algorithmiaio/mounted-scripts/customize-container.sh: not found`, so copying the scripts from the build context directory's location to the expected execution location.

Validated that builds completed successfully in cluster