### PR TITLE
ALGO-789 Tensorflow 2.3.X support

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -8,17 +8,9 @@ COPY --chown=algo:algo {{config.local_dependency_src_path}} {{config.local_depen
 {% endif %}
 
 ENV HOME=/home/algo
-{% if config.local_dependency_src_path is defined %}
 # Custom CA certs won't be available when testing locally
 USER algo
 RUN /usr/local/bin/algorithmia-build
-{% else %}
-# customize-container.sh runs as root, then switches to user of less privilege
-USER root
-COPY mounted-scripts /opt/algorithmiaio/mounted-scripts
-COPY ca-certificates /opt/algorithmia/ca-certificates
-RUN /opt/algorithmiaio/mounted-scripts/customize-container.sh algo /usr/local/bin/algorithmia-build
-{% endif %}
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -8,9 +8,17 @@ COPY --chown=algo:algo {{config.local_dependency_src_path}} {{config.local_depen
 {% endif %}
 
 ENV HOME=/home/algo
+{% if local is defined %}
 # Custom CA certs won't be available when testing locally
 USER algo
 RUN /usr/local/bin/algorithmia-build
+{% else %}
+# customize-container.sh runs as root, then switches to user of less privilege
+USER root
+COPY mounted-scripts /opt/algorithmiaio/mounted-scripts
+COPY ca-certificates /opt/algorithmia/ca-certificates
+RUN /opt/algorithmiaio/mounted-scripts/customize-container.sh algo /usr/local/bin/algorithmia-build
+{% endif %}
 
 FROM {{runner_image}}
 {% for artifact in config.artifacts %}

--- a/libraries/tensorflow-gpu-2.3/Dockerfile
+++ b/libraries/tensorflow-gpu-2.3/Dockerfile
@@ -1,0 +1,2 @@
+#RUN pip install keras==2.3.1
+RUN pip install "tensorflow-gpu>=2.2,<2.3"

--- a/templates/tensorflow-gpu-2.3/algorithmia.conf
+++ b/templates/tensorflow-gpu-2.3/algorithmia.conf
@@ -1,0 +1,5 @@
+{
+    "username": "__USER__",
+    "algoname": "__ALGO__",
+    "language": "python-3.x-1"
+}

--- a/templates/tensorflow-gpu-2.3/requirements.txt
+++ b/templates/tensorflow-gpu-2.3/requirements.txt
@@ -1,0 +1,3 @@
+algorithmia>=1.0.0,<2.0
+six
+tensorflow-gpu>=2.3,<2.4 # if you need a different version, please change this value - bear in mind that it may take longer to compile.

--- a/templates/tensorflow-gpu-2.3/src/__ALGO__.py
+++ b/templates/tensorflow-gpu-2.3/src/__ALGO__.py
@@ -1,0 +1,69 @@
+import Algorithmia
+import tensorflow.keras.backend as K
+from tensorflow import convert_to_tensor
+import tensorflow as tf
+import numpy as np
+
+"""
+Example Input:
+{
+    "matrix_a": [[0, 1], [1, 0]],
+    "matrix_b": [[25, 25], [11, 11]]
+}
+
+Expected Output:
+{
+    "product": [[11, 11], [25, 25]]
+}
+"""
+
+# Configure Tensorflow to only use up to 30% of the GPU.
+gpus = tf.config.experimental.list_physical_devices('GPU')
+tf.config.experimental.set_memory_growth(gpus[0], True)
+tf.config.experimental.set_virtual_device_configuration(gpus[0], [tf.config.experimental.VirtualDeviceConfiguration(memory_limit=3432)])
+
+class InputObject:
+    def __init__(self, input_dict):
+        """
+        Creates an instance of the InputObject, which checks the format of data and throws exceptions if anything is
+        missing.
+        "matrix_a" and "matrix_b" must be the same shape.
+
+        :param A - Matrix A, converted from a json list into a keras Tensor.
+        :param B - Matrix B, converted from a json list into a keras Tensor.
+        """
+        if isinstance(input_dict, dict):
+            if {'matrix_a', 'matrix_b'} <= input_dict.keys():
+                self.A = convert(input_dict['matrix_a'])
+                self.B = convert(input_dict['matrix_b'])
+            else:
+                raise Exception("'matrix_a' and 'matrix_b' must be defined.")
+        else:
+            raise Exception('input must be a json object.')
+        if self.A.shape[-1] != self.B.shape[0]:
+            raise Exception('inner dimensions between A and B must be the same.\n A: {} B: {}'.format(self.A.shape[-1],
+                                                                                                      self.B.shape[0]))
+
+
+def convert(list_array):
+    """
+    Converts a json list into a keras Tensor object.
+    """
+    numpy_object = np.asarray(list_array, dtype=np.float)
+    tensor_object = convert_to_tensor(numpy_object)
+    return tensor_object
+
+def apply(input):
+    """
+    Calculates the dot product of two matricies using keras, with a tensorflow-gpu backend.
+    Returns the product as the output.
+    """
+    input = InputObject(input)
+
+    z = K.dot(input.A, input.B)
+    # Here you need to use K.eval() instead of z.eval() because this uses the backend session
+    K.eval(z)
+    z = K.get_value(z)
+    output = {'product': z.tolist()}
+    return output
+

--- a/templates/tensorflow-gpu-2.3/src/__ALGO___test.py
+++ b/templates/tensorflow-gpu-2.3/src/__ALGO___test.py
@@ -1,0 +1,7 @@
+from .__ALGO__ import apply
+
+
+def test_algorithm():
+    input = {"matrix_a": [[0, 1], [1, 0]], "matrix_b": [[25, 25], [11, 11]]}
+    result = apply(input)
+    assert result == {"product": [[11., 11.], [25., 25.]]}

--- a/tools/template_manager.py
+++ b/tools/template_manager.py
@@ -54,7 +54,8 @@ def generate_compile_image(builder_image_name, runner_image_name, config_data, o
     generated_template = raw_template.render(
         builder_image=builder_image_name,
         runner_image=runner_image_name,
-        config=config_data
+        config=config_data,
+        local=True,
     )
     save_generated_template(generated_template, output_file_path)
     return output_file_path


### PR DESCRIPTION
This PR includes a new Tensorflow 2.3. package support for python 3.7. To test this, please go to the langpacks directory on a gpu enabled computer (deepPurple is a good bet) and run the following command:
`$ ./tools/environment_validator.py -b nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 -g python3 -s python37 -d tensorflow-gpu-2.3 -t dependency -n tensorflow-gpu-2.3 --nvidia-support 1`

after that's done, on a separate tab (same machine) provide the following input:
`$ curl localhost:9999 -H 'Content-Type: application/json' -d '{
    "matrix_a": [[0, 1], [1, 0]],
    "matrix_b": [[25, 25], [11, 11]]
}'`

If this returns successfully, then you've been able to verify the functionality of the algorithm and package set
