### PR TITLE
[PSE-245] Package mirror arguments for use in IPA build and execution

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -1,4 +1,9 @@
 FROM {{builder_image}} as builder
+ARG CRAN_MIRROR
+ARG IVY_MIRROR
+ARG MAVEN_MIRROR
+ARG NPM_REGISTRY
+ARG PYTHON_INDEX_URL
 
 # Docker build commands don't resolve environment variables so need this to either be numeric or a build argument
 COPY --chown=algo:algo algosource /opt/algorithm/
@@ -21,6 +26,12 @@ RUN /opt/algorithmiaio/mounted-scripts/customize-container.sh algo /usr/local/bi
 {% endif %}
 
 FROM {{runner_image}}
+ARG CRAN_MIRROR
+ARG IVY_MIRROR
+ARG MAVEN_MIRROR
+ARG NPM_REGISTRY
+ARG PYTHON_INDEX_URL
+
 {% for artifact in config.artifacts %}
 COPY --from=builder --chown=algo:algo {{artifact.source}} {{artifact.destination}}
 {% endfor %}

--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -26,11 +26,6 @@ RUN /opt/algorithmiaio/mounted-scripts/customize-container.sh algo /usr/local/bi
 {% endif %}
 
 FROM {{runner_image}}
-ARG CRAN_MIRROR
-ARG IVY_MIRROR
-ARG MAVEN_MIRROR
-ARG NPM_REGISTRY
-ARG PYTHON_INDEX_URL
 
 {% for artifact in config.artifacts %}
 COPY --from=builder --chown=algo:algo {{artifact.source}} {{artifact.destination}}


### PR DESCRIPTION
Five package mirror arguments are added to the _builder_ image; `CRAN_MIRROR` is passed into `langserver`'s environment during algorithm execution.

This supports both IPA algorithm builds and IPA algorithm executions:
- https://github.com/algorithmiaio/containers/pull/185
- https://github.com/algorithmiaio/docker-builder/pull/1
- https://github.com/algorithmiaio/node-autoscaler/pull/148