### PR TITLE
[PSE] Add (Environments) designation to language display names

### DIFF
--- a/languages/anaconda3/config.json
+++ b/languages/anaconda3/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Anaconda 3.5x",
+    "display_name": "Anaconda 3.5x (Environments)",
     "artifacts": [
       {"source":"/home/algo/.cache", "destination":"/home/algo/.cache/"},
       {"source":"/home/algo/anaconda_environment", "destination": "/home/algo/anaconda_environment/"},

--- a/languages/csharp-dotnet-core2/config.json
+++ b/languages/csharp-dotnet-core2/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "C# .NET Core 2.x+",
+    "display_name": "C# .NET Core 2.x+ (Environments)",
     "artifacts": [
         {"source":"/opt/algorithm/bin/Release/*/*", "destination":"/opt/algorithm/"},
         {"source":"/opt/algorithm/resources", "destination":"/opt/algorithm/resources/"},

--- a/languages/java11/config.json
+++ b/languages/java11/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Java OpenJDK 11.0",
+    "display_name": "Java OpenJDK 11.0 (Environments)",
     "artifacts": [
         {"source":"/opt/algorithm/target/*.jar", "destination":"/opt/algorithm/target/algorithm.jar"},
         {"source":"/opt/algorithm/target/lib", "destination":"/opt/algorithm/target/lib/"}

--- a/languages/python2/config.json
+++ b/languages/python2/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Python 2.x",
+    "display_name": "Python 2.x (Environments)",
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
         {"source":"/opt/algorithm", "destination":"/opt/algorithm/"}

--- a/languages/python3/config.json
+++ b/languages/python3/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Python 3.x",
+    "display_name": "Python 3.x (Environments)",
     "artifacts": [
         {"source":"/home/algo/.local", "destination":"/home/algo/.local/"},
         {"source":"/opt/algorithm", "destination":"/opt/algorithm/"}

--- a/languages/r36/config.json
+++ b/languages/r36/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "R 3.6.x",
+    "display_name": "R 3.6.x (Environments)",
     "artifacts": [
       {"source":"/opt/algorithm", "destination":"/opt/algorithm/"},
       {"source":"/usr/local/lib/R/site-library", "destination":"/usr/local/lib/R/site-library/"}

--- a/languages/scala-2/config.json
+++ b/languages/scala-2/config.json
@@ -1,5 +1,5 @@
 {
-    "display_name": "Scala 2.x & sbt 1.3.x",
+    "display_name": "Scala 2.x & sbt 1.3.x (Environments)",
     "artifacts": [
       {"source":"/opt/algorithm/target/universal/stage", "destination":"/opt/algorithm/stage/"}
     ]


### PR DESCRIPTION
The Algorithm Environment Manager gets the list of languages and their configuration from Legit on startup, which uses the language `config.json` files from this repository. In this PR, I'm updating the display names to match the manual fixup that was done during our release to test and production marketplace. The "(Environments)" designation will disappear over the next few sprints, once we settle upon a migration path from legacy to the new algorithm environments, with input from the product team.

![Screenshot from 2020-08-26 16-38-16](https://user-images.githubusercontent.com/43390442/91354359-a10ae300-e7ba-11ea-8dea-7a86c275ab75.png)
