### PR TITLE
Set default repository and pluginRepositories that will point at HTTPS maven

### DIFF
--- a/java/template/pom.xml
+++ b/java/template/pom.xml
@@ -1,5 +1,30 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <modelVersion>4.0.0</modelVersion>
     <groupId>algorithmia.__ALGO__</groupId>
     <artifactId>__ALGO__</artifactId>

--- a/languages/java11/template/pom.xml
+++ b/languages/java11/template/pom.xml
@@ -6,6 +6,31 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+    <repositories>
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.algorithmia</groupId>
     <artifactId>algorithm</artifactId>

--- a/languages/scala-2/template/build.sbt
+++ b/languages/scala-2/template/build.sbt
@@ -3,7 +3,7 @@ organization := "algorithmia"
 version := "0.1"
 scalaVersion := "2.13.1"
 
-resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
+resolvers += Resolver.typesafeRepo("releases")
 
 enablePlugins(JavaAppPackaging)
 
@@ -11,4 +11,3 @@ libraryDependencies ++= Seq(
   "com.algorithmia" %% "algorithmia-scala" % "1.0.+",
   "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
-

--- a/scala/template/build.sbt
+++ b/scala/template/build.sbt
@@ -13,9 +13,7 @@ scalaVersion := "2.11.11"
 
 mainClass in Compile := Some("algorithmia.Main")
 
-val repoUrl = System.getProperty("repo.url", "http://git.algorithmia.com")
-
-resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += Resolver.typesafeRepo("releases")
 
 libraryDependencies ++= Seq(
   "com.algorithmia" % "algorithmia-client" % "1.0.+",


### PR DESCRIPTION
Prior to this, without setting the maven mirrors we would get errors like:
```
[ERROR] Plugin org.apache.maven.plugins:maven-resources-plugin:2.3 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.maven.plugins:maven-resources-plugin:jar:2.3: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:2.3 from/to central (http://repo.maven.apache.org/maven2): Failed to transfer file: http://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.3/maven-resources-plugin-2.3.pom. Return code is: 501 , ReasonPhrase:HTTPS Required. -> [Help 1]
```

This sets the needed variables for pluginRepositories as well, which should still be overridden in appropriate maven mirrors/proxy settings in the `~/.m2/settings.xml` if needed.  See: https://stackoverflow.com/a/59781316.

I validated this by running `mvn package` inside of a build container and seeing the error, then I updated the pom.xml with the given date and it succeeded.