### PR TITLE
removed deprecated API key from template

### DIFF
--- a/templates/mleap_databricks/src/main/scala/com/algorithmia/Algorithm.scala
+++ b/templates/mleap_databricks/src/main/scala/com/algorithmia/Algorithm.scala
@@ -15,7 +15,7 @@ import scala.util.{Failure, Success, Try}
 class Algorithm extends AbstractAlgorithm[InputExample, String] {
   var loaded_state = new mutable.HashMap[String, Bundle[Transformer]]()
   val model_uri = "data://zeryx/databricks/simple-spark-pipeline.zip"
-  val client: AlgorithmiaClient = Algorithmia.client("simWKYsJU/gOwvomS2k2kyvvlvy1")
+  val client: AlgorithmiaClient = Algorithmia.client()
 
 
   override def load(): Try[Unit] = {


### PR DESCRIPTION
oof good catch @kennydaniel, key has thankfully been deprecated immediately after the push; but I forgot to remove the key from the template.