### PR TITLE
Added python38 (3.8.6) support with pip v20.2.4

### DIFF
--- a/libraries/python38/Dockerfile
+++ b/libraries/python38/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get -y update && \
 # ensure local python is preferred over distribution python
 ENV PATH /usr/local/bin:$PATH
 
-ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+ENV GPG_KEY E3FF2839C048B25C084DEBE9B26995E310250568
 ENV PYTHON_VERSION 3.8.6
 
 # Setting keyserver per https://github.com/tianon/gosu/issues/17#issuecomment-203074866

--- a/libraries/python38/Dockerfile
+++ b/libraries/python38/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get -y update && \
 ENV PATH /usr/local/bin:$PATH
 
 ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
-ENV PYTHON_VERSION 3.9.0
+ENV PYTHON_VERSION 3.8.6
 
 # Setting keyserver per https://github.com/tianon/gosu/issues/17#issuecomment-203074866
 RUN set -ex \

--- a/libraries/python39/Dockerfile
+++ b/libraries/python39/Dockerfile
@@ -1,0 +1,116 @@
+# Lightly modified from https://github.com/docker-library/python/blob/ab8b829cfefdb460ebc17e570332f0479039e918/3.7/stretch/Dockerfile
+
+RUN apt-get -y update && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    ca-certificates \
+    checkinstall \
+    libbz2-dev \
+    libc6-dev \
+    libffi-dev \
+    libgdbm-dev \
+    libncursesw5-dev \
+    libreadline-gplv2-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    tk-dev \
+    uuid-dev \
+    wget \
+    gnupg \
+    gnupg2 \
+    git && \
+    rm -rf /var/lib/apt/lists/*
+
+# MIT license from initial repo
+# Copyright (c) 2014 Docker, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# ensure local python is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
+
+ENV GPG_KEY 0D96DF4D4110E5C43FBFB17F2D347EA6AA65421D
+ENV PYTHON_VERSION 3.9.0
+
+# Setting keyserver per https://github.com/tianon/gosu/issues/17#issuecomment-203074866
+RUN set -ex \
+    \
+    && wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" \
+    && wget -O python.tar.xz.asc "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && $(gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$GPG_KEY" ||  gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "$GPG_KEY") \
+    && gpg --batch --verify python.tar.xz.asc python.tar.xz \
+    && { command -v gpgconf > /dev/null && gpgconf --kill all || :; } \
+    && rm -rf "$GNUPGHOME" python.tar.xz.asc \
+    && mkdir -p /usr/src/python \
+    && tar -xJC /usr/src/python --strip-components=1 -f python.tar.xz \
+    && rm python.tar.xz \
+    \
+    && cd /usr/src/python \
+    && gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+    && ./configure \
+    --build="$gnuArch" \
+    --enable-loadable-sqlite-extensions \
+    --enable-shared \
+    --with-system-expat \
+    --with-system-ffi \
+    --without-ensurepip \
+    && make -j "$(nproc)" \
+    && make install \
+    && ldconfig \
+    \
+    && find /usr/local -depth \
+    \( \
+    \( -type d -a \( -name test -o -name tests \) \) \
+    -o \
+    \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+    \) -exec rm -rf '{}' + \
+    && rm -rf /usr/src/python \
+    \
+    && python3 --version
+
+# make some useful symlinks that are expected to exist
+RUN cd /usr/local/bin \
+    && ln -s idle3 idle \
+    && ln -s pydoc3 pydoc \
+    && ln -s python3 python \
+    && ln -s python3-config python-config
+
+# if this is called "PIP_VERSION", pip explodes with "ValueError: invalid truth value '<VERSION>'"
+ENV PYTHON_PIP_VERSION 20.2.4
+
+RUN set -ex; \
+    \
+    wget -O get-pip.py 'https://bootstrap.pypa.io/get-pip.py'; \
+    \
+    python get-pip.py \
+    --disable-pip-version-check \
+    --no-cache-dir \
+    "pip==$PYTHON_PIP_VERSION" \
+    ; \
+    pip --version; \
+    \
+    find /usr/local -depth \
+    \( \
+    \( -type d -a \( -name test -o -name tests \) \) \
+    -o \
+    \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+    \) -exec rm -rf '{}' +; \
+    rm -f get-pip.py


### PR DESCRIPTION
Hey James, this branch is adding Python38 support with the Dockerfile under `libraries`, installing Python v3.8.6 with pip v20.2.4.

Tested on deeppurple for 2 different algorithms but will continue testing this further. For now it works okay for

1. An algorithm that's failing on the marketplace on python37 env:
```
./tools/environment_validator.py -b ubuntu:16.04 -g python3 -s python38 -t dependency -n albert_classification -c 1 -k sim0/CA0mCa6Xz3FAkyoHb45G5I1
```
verified with: 
```
 curl localhost:9999 -H 'Content-Type: application/json' -d '{ "texts": "asli" }'
```

2. Testing with the usual TF template on CPU: 
```
./tools/environment_validator.py -b ubuntu:16.04 -g python3 -s python38 -d tensorflow-cpu-2.3 -t dependency -n tensorflow-cpu-2.3 -c 1
```
verified with: 
```
curl localhost:9999 -H 'Content-Type: application/json' -d '{ "matrix_a": [[0, 1], [1, 0]], "matrix_b": [[25, 25], [11, 11]] }'
```

Thanks as always for the review!



