### PR TITLE
ALGO-XXX added requirement file logic (from caching PR) to R

### DIFF
--- a/languages/r36/config.json
+++ b/languages/r36/config.json
@@ -1,5 +1,8 @@
 {
     "display_name": "R 3.6.x (Environments)",
+      "req_files": [
+        "packages.txt"
+    ],
     "artifacts": [
       {"source":"/opt/algorithm", "destination":"/opt/algorithm/"},
       {"source":"/usr/local/lib/R/site-library", "destination":"/usr/local/lib/R/site-library/"}


### PR DESCRIPTION
thanks to @danielfrg for adding our requirement file caching logic. With this change we now have package caching available for R.

Easy way to test:
run `./tools/environment_validator.py -s r36 -t language -n r36`
temporarily modify `~/languages/r36/template/src/Algorithm.R` to verify code changes don't invalidate cache
execute `./tools/environment_validator.py -s r36 -t language -n r36` again and note compilation time performance.