### PR TITLE
PSE-540 Update algorithmia-java-extras and algorithmia-client versions

### DIFF
--- a/java/template/pom.xml
+++ b/java/template/pom.xml
@@ -42,13 +42,13 @@
         <dependency>
             <groupId>com.algorithmia</groupId>
             <artifactId>algorithmia-extras</artifactId>
-            <version>[1.0.2,)</version>
+            <version>[1.0.4,2.0)</version>
         </dependency>
 
         <dependency>
             <groupId>com.algorithmia</groupId>
             <artifactId>algorithmia-client</artifactId>
-            <version>[1.0.15,)</version>
+            <version>[1.0.15,2.0)</version>
         </dependency>
 
         <dependency>

--- a/java/template/pom.xml
+++ b/java/template/pom.xml
@@ -42,13 +42,13 @@
         <dependency>
             <groupId>com.algorithmia</groupId>
             <artifactId>algorithmia-extras</artifactId>
-            <version>[1.0.1,)</version>
+            <version>[1.0.2,)</version>
         </dependency>
 
         <dependency>
             <groupId>com.algorithmia</groupId>
             <artifactId>algorithmia-client</artifactId>
-            <version>[1.0.11,)</version>
+            <version>[1.0.15,)</version>
         </dependency>
 
         <dependency>

--- a/languages/java11/template/pom.xml
+++ b/languages/java11/template/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.algorithmia</groupId>
             <artifactId>algorithmia-client</artifactId>
-            <version>[1.0.15,)</version>
+            <version>[1.0.15,2.0)</version>
         </dependency>
         <dependency>
             <groupId>com.algorithmia</groupId>

--- a/languages/java11/template/pom.xml
+++ b/languages/java11/template/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.algorithmia</groupId>
             <artifactId>algorithmia-client</artifactId>
-            <version>[1.0.11,)</version>
+            <version>[1.0.15,)</version>
         </dependency>
         <dependency>
             <groupId>com.algorithmia</groupId>


### PR DESCRIPTION
See https://algorithmia.atlassian.net/browse/PSE-540?atlOrigin=eyJpIjoiN2ZlYzgyZWE0OTFiNGQyNWFlMDViY2QzYjhkZTA2MmIiLCJwIjoiaiJ9 for more details.

Updating the java client library versions to remove the Maven warnings trying to pull problematic dependencies sbt-pgp and sbt-sonatype. 

Feel free to add any additional reviewers as necessary.