### PR TITLE
ALGO-890 added lzma to all python base images

### DIFF
--- a/libraries/anaconda35/Dockerfile
+++ b/libraries/anaconda35/Dockerfile
@@ -3,7 +3,7 @@ ENV PATH /opt/conda/bin:$PATH
 ENV ANACONDA_ENV=/home/algo/anaconda_environment
 
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
-    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    libglib2.0-0 libxext6 libsm6 libxrender1 liblzma-dev \
     curl grep sed dpkg \
     git  && \
     apt-get clean && \

--- a/libraries/anaconda49/Dockerfile
+++ b/libraries/anaconda49/Dockerfile
@@ -3,7 +3,7 @@ ENV PATH /opt/conda/bin:$PATH
 ENV ANACONDA_ENV=/home/algo/anaconda_environment
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y wget bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 git && \
+    apt-get install -y wget bzip2 ca-certificates libglib2.0-0 libxext6 libsm6 libxrender1 liblzma-dev git && \
     apt-get clean
 
 RUN wget --quiet https://github.com/conda-forge/miniforge/releases/download/4.9.0-3/Miniforge3-4.9.0-3-Linux-x86_64.sh -O ~/miniforge.sh && \

--- a/libraries/python27/Dockerfile
+++ b/libraries/python27/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y update && \
         tk-dev \
         uuid-dev \
         wget \
+        liblzma-dev \
         git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/libraries/python36/Dockerfile
+++ b/libraries/python36/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y update && \
         tk-dev \
         uuid-dev \
         wget \
+        liblzma-dev \
         git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/libraries/python37/Dockerfile
+++ b/libraries/python37/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y update && \
         wget \
         gnupg \
 		gnupg2 \
+		liblzma-dev \
         git && \
     rm -rf /var/lib/apt/lists/*
 

--- a/libraries/python38/Dockerfile
+++ b/libraries/python38/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -y update && \
     wget \
     gnupg \
     gnupg2 \
+    liblzma-dev \
     git && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
URGENT:
lzma support is a blocker for one of our customers.
# To Test
` ./tools/environment_validator.py -g python[x] -s python[x] -t language -n python[x]`
^ please test the construction of each version of python that we support:
* python27
* python36
* python37
* python38

Please also verify with a simple `import pandas as pd` that we no longer get the lzma warning, to sanity check that the `lzma` package is installed.