### PR TITLE
Add libv8 to R docker image

### DIFF
--- a/libraries/r36/Dockerfile
+++ b/libraries/r36/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update \
     ca-certificates \
     git \
     libcurl4-gnutls-dev \
-    wget
+    wget \
+    libv8-dev
 
 RUN Rscript -e "install.packages(c('rjson', 'base64enc', 'RCurl', 'pacman'))"
 


### PR DESCRIPTION
Adding a missing dependency for `prophet` to work in R 3.6.

Initially I thought it was a memory constrain so be sure to give docker some memory when testing this.

This only adds `libv8-dev` as a system dep for `rstan` that actually depends on the R `V8` packages which is an interface to V8.

To test:

```
./tools/environment_validator.py -b ubuntu:16.04 -n r36 -g r36 -s r36 -t language
```

Add `prophet` to the `packages.txt` and `library(prophet)` to the `Algorithm.R`  in the R template.

Talked with @kennydaniel and we agreed to add this instead of having a diff env just for this deps.
