### PR TITLE
ALGO-965 Spacy 3.0.x support

### DIFF
--- a/libraries/spacy-3.0.x/Dockerfile
+++ b/libraries/spacy-3.0.x/Dockerfile
@@ -1,0 +1,9 @@
+
+RUN pip install "spacy>=3.0,<3.1"
+RUN python -m spacy download en_core_web_sm
+RUN python -m spacy download de_core_news_sm
+RUN python -m spacy download es_core_news_sm
+RUN python -m spacy download pt_core_news_sm
+RUN python -m spacy download fr_core_news_sm
+RUN python -m spacy download it_core_news_sm
+RUN python -m spacy download nl_core_news_sm

--- a/templates/spacy-3.0.x/algorithmia.conf
+++ b/templates/spacy-3.0.x/algorithmia.conf
@@ -1,0 +1,5 @@
+{
+    "username": "__USER__",
+    "algoname": "__ALGO__",
+    "language": "python-3.x-1"
+}

--- a/templates/spacy-3.0.x/requirements.txt
+++ b/templates/spacy-3.0.x/requirements.txt
@@ -1,0 +1,3 @@
+algorithmia>=1.0.0,<2.0
+six
+spacy>=3.0,<3.1  # if you need a different version, please change this value - bear in mind however that it may take longer to compile.

--- a/templates/spacy-3.0.x/src/__ALGO__.py
+++ b/templates/spacy-3.0.x/src/__ALGO__.py
@@ -1,0 +1,44 @@
+import Algorithmia
+import spacy
+
+"""
+This package set comes preinstalled with every available small language package provided by spacy.
+Pick your language from the following list: 'en', 'es', 'pt', 'fr', 'it', 'de, and 'nl', and add the suffix '_core_news_sm' to it.
+You may change the language at runtime, but bear in mind that you'll get hit with some performance loss.
+
+Example Input:
+"I like New York in Autumn, the trees are beautiful."
+
+Expected Output:
+{
+    "entities found": [
+        {"label": "GPE", "text": "New York"},
+        {"label": "DATE", "text": "Autumn"}
+    ]
+}
+"""
+
+LANG = "en_core_news_sm"
+
+def load_spacy_lang(language):
+    lang_model = spacy.load(language)
+    return lang_model
+
+
+def apply(input):
+    """
+    This algorithm performs "Named Entity Recognition" on the sample input document.
+    It expects the input to be an escaped string.
+    :param input: An escaped string, in the language defined by $LANG.
+    :return: a list of detected entities.
+    """
+    document = nlp(input)
+    named_entities = []
+    for ent in document.ents:
+        entity = {"label": ent.label_, "text": ent.text}
+        named_entities.append(entity)
+    output = {"entities found": named_entities}
+    return output
+
+
+nlp = load_spacy_lang(LANG)

--- a/templates/spacy-3.0.x/src/__ALGO__.py
+++ b/templates/spacy-3.0.x/src/__ALGO__.py
@@ -3,7 +3,7 @@ import spacy
 
 """
 This package set comes preinstalled with every available small language package provided by spacy.
-Pick your language from the following list: 'en', 'es', 'pt', 'fr', 'it', 'de, and 'nl', and add the suffix '_core_news_sm' to it.
+Pick your language from the following list:'en','es', 'pt', 'fr', 'it', 'de, and 'nl', and add the suffix '_core_news_sm' to it if it's not english.
 You may change the language at runtime, but bear in mind that you'll get hit with some performance loss.
 
 Example Input:
@@ -18,7 +18,7 @@ Expected Output:
 }
 """
 
-LANG = "en_core_news_sm"
+LANG = "en_core_web_sm"
 
 def load_spacy_lang(language):
     lang_model = spacy.load(language)

--- a/templates/spacy-3.0.x/src/__ALGO___test.py
+++ b/templates/spacy-3.0.x/src/__ALGO___test.py
@@ -1,0 +1,7 @@
+from .__ALGO__ import apply
+
+
+def test_algorithm():
+    input = "I like New York in Autumn, the trees are beautiful."
+    result = apply(input)
+    assert result == {"entities found": [{"label": "GPE", "text": "New York"}, {"label": "DATE", "text": "Autumn"}]}


### PR DESCRIPTION
[ALGO-965](https://algorithmia.atlassian.net/browse/ALGO-965) - Spacy 3.0.x Support

This PR adds support for Spacy 3.0.x, which can be verified with the following validator command:
`./tools/environment_validator.py -b ubuntu:20.04 -g python3 -s python37 -d spacy-3.0.x -t dependency -n spacy-3.0.x`
