### PR TITLE
added libsndfile-dev dependencies to oracle and pytorch cpu packages

### DIFF
--- a/libraries/oracle19.9/Dockerfile
+++ b/libraries/oracle19.9/Dockerfile
@@ -1,6 +1,6 @@
 RUN apt-get update && apt-get install -y \
     alien dpkg-dev debhelper build-essential \
-    libaio1 && \
+    libaio1 libsndfile-dev && \
     wget https://download.oracle.com/otn_software/linux/instantclient/199000/oracle-instantclient19.9-basic-19.9.0.0.0-1.x86_64.rpm && \
     alien -i oracle-instantclient19.9-basic-19.9.0.0.0-1.x86_64.rpm
 

--- a/libraries/pytorch-cpu-1.6.x/Dockerfile
+++ b/libraries/pytorch-cpu-1.6.x/Dockerfile
@@ -1,2 +1,5 @@
+
+RUN apt-get update && \
+  apt-get install -y libsndfile-dev
 RUN pip install numpy==1.16.0
 RUN pip install "torch>=1.6.0,<1.7.0"


### PR DESCRIPTION
This modification adds support for `torchaudio`, which uses librosa and `sndfile`; a system level dependency.