### PR TITLE
[PSE-2049] Remove linebreak stripping from if statement to ensure templating functions correctly

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -7,7 +7,7 @@ ARG PYTHON_INDEX_URL
 ARG JAVA_TOOL_OPTIONS_BUILD
 
 {# If there is explicit req_files then we add those first and build based on those #}
-{%- if config.req_files is defined -%}
+{% if config.req_files is defined -%}
 # Copying dependecies before copying the algo source
 {% for build_file in config.req_files -%}
 COPY --chown=algo:algo algosource/{{ build_file }} /opt/algorithm/{{ build_file }}


### PR DESCRIPTION
Different versions of jinja parsing might result in removing too many newlines from this dockerfile and end up with a line like `ARG JAVA_TOOL_OPTIONS_BUILD# Copying dependecies before copying the algo source` which is marked as an invalid dockerfile syntax.

Validated against a service that renders this template, will have separate PR for that forthcoming

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If I made configuration changes, they are in the config template in the deploy directory
- [ ] I have added unit tests where appropriate
- [ ] I have added integration tests where appropriate
- [ ] Manual tests are required in a cluster

## Backporting
This will need to be merged into the following support branches:
