### PR TITLE
[PSE-1439] Set JAVA_TOOL_OPTIONS in a second place

### DIFF
--- a/languages/Dockerfile.compile.j2
+++ b/languages/Dockerfile.compile.j2
@@ -48,6 +48,8 @@ RUN /usr/local/bin/algorithmia-build
 USER root
 COPY mounted-scripts /opt/algorithmiaio/mounted-scripts
 COPY ca-certificates /opt/algorithmia/ca-certificates
+# Update JAVA_TOOL_OPTIONS with those required for this specific build which might include proxy variables
+ENV JAVA_TOOL_OPTIONS "$JAVA_TOOL_OPTIONS_BUILD $JAVA_TOOL_OPTIONS"
 RUN /opt/algorithmiaio/mounted-scripts/customize-container-v2.sh algo /usr/local/bin/algorithmia-build
 {%- endif %}
 {%- endif %}


### PR DESCRIPTION
[PSE-1439](https://algorithmia.atlassian.net/browse/PSE-1439) - [This PR](https://github.com/algorithmiaio/langpacks/pull/205) made sure the values were set in one place but the template calls the build script in two places so the second one also needs to be set 

## Checklist
- [x] My PR title includes a relevant Jira ticket name
- [ ] If I made configuration changes, they are in the config template in the deploy directory
- [ ] I have added unit tests where appropriate
- [ ] I have added integration tests where appropriate
- [x] Manual tests are required in a cluster -> made this change manually on a cluster

## Backporting
This will need to be merged into the following support branches:
